### PR TITLE
Fix taxfree_after_period db read

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,8 @@
 Changelog
 =========
 
+:bug: `77` Fix bug cause by reading `taxfree_after_period` from the database
+
 * :release:`0.2.2 <2018-06-05>`
 
 :bug: `73` Fixer.io api switched to be subscription based and its endpoints are now locked, so we switch to a different currency converter api.

--- a/rotkehlchen/accounting/events.py
+++ b/rotkehlchen/accounting/events.py
@@ -53,6 +53,7 @@ class TaxableEvents(object):
 
     @taxfree_after_period.setter
     def taxfree_after_period(self, value):
+        assert isinstance(value, int), 'set taxfree_after_period should only get int'
         self._taxfree_after_period = value
 
     def calculate_asset_details(self):

--- a/rotkehlchen/accounting/events.py
+++ b/rotkehlchen/accounting/events.py
@@ -53,7 +53,8 @@ class TaxableEvents(object):
 
     @taxfree_after_period.setter
     def taxfree_after_period(self, value):
-        assert isinstance(value, int), 'set taxfree_after_period should only get int'
+        is_valid = isinstance(value, int) or value is None
+        assert is_valid, 'set taxfree_after_period should only get int or None'
         self._taxfree_after_period = value
 
     def calculate_asset_details(self):

--- a/rotkehlchen/db/dbhandler.py
+++ b/rotkehlchen/db/dbhandler.py
@@ -204,6 +204,8 @@ class DBHandler(object):
                 settings['last_data_upload_ts'] = int(q[1])
             elif q[0] == 'ui_floating_precision':
                 settings['ui_floating_precision'] = int(q[1])
+            elif q[0] == 'taxfree_after_period':
+                settings['taxfree_after_period'] = int(q[1])
             else:
                 settings[q[0]] = q[1]
 

--- a/rotkehlchen/tests/test_db.py
+++ b/rotkehlchen/tests/test_db.py
@@ -260,3 +260,30 @@ def test_upgrade_db_1_to_2(data_dir, username):
     accounts = data.db.get_blockchain_accounts()
     assert accounts['ETH'][0] == '0xe3580C38B0106899F45845E361EA7F8a0062Ef12'
     assert data.db.get_version() == ROTKEHLCHEN_DB_VERSION
+
+
+def test_settings_entry_types(data_dir, username):
+    data = DataHandler(data_dir)
+    data.unlock(username, '123', create_new=True)
+
+    data.db.set_settings({
+        'version': 1,
+        'last_write_ts': 1,
+        'premium_should_sync': True,
+        'include_crypto2crypto': True,
+        'last_data_upload_ts': 1,
+        'ui_floating_precision': 1,
+        'taxfree_after_period': 1,
+        'historical_data_start': '01/08/2015',
+        'eth_rpc_port': '8545',
+    })
+
+    res = data.db.get_settings()
+    assert isinstance(res['db_version'], int)
+    assert isinstance(res['last_write_ts'], int)
+    assert isinstance(res['premium_should_sync'], bool)
+    assert isinstance(res['include_crypto2crypto'], bool)
+    assert isinstance(res['ui_floating_precision'], int)
+    assert isinstance(res['taxfree_after_period'], int)
+    assert isinstance(res['historical_data_start'], str)
+    assert isinstance(res['eth_rpc_port'], str)


### PR DESCRIPTION
- Fix taxfree_after_period reading from DB. Make sure it's an int.
- Add a test for the types of DB setting attributes

Fixes #77 