### PR TITLE
Fix kraken/binance key validation error

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,9 +2,11 @@
 Changelog
 =========
 
+* :bug: `99` Show proper error if kraken or binance api key validation fails due to an invalid key having been provided.
+
 * :release:`0.3.1 <2018-06-25>`
 
-* :bug: `96` Periodic balance data storage should now also work from the UI
+* :bug: `96` Periodic balance data storage should now also work from the UI.
 
 * :release:`0.3.0 <2018-06-24>`
 

--- a/rotkehlchen/binance.py
+++ b/rotkehlchen/binance.py
@@ -99,9 +99,9 @@ class Binance(Exchange):
             error = str(e)
             if 'API-key format invalid' in error:
                 return False, 'Provided API Key is in invalid Format'
-            elif 'Signature for this request is not valid':
+            elif 'Signature for this request is not valid' in error:
                 return False, 'Provided API Secret is malformed'
-            elif 'Invalid API-key, IP, or permissions for action':
+            elif 'Invalid API-key, IP, or permissions for action' in error:
                 return False, 'API Key does not match the given secret'
             else:
                 raise

--- a/rotkehlchen/kraken.py
+++ b/rotkehlchen/kraken.py
@@ -144,7 +144,7 @@ class Kraken(Exchange):
             error = str(e)
             if 'Error: Incorrect padding' in error:
                 return False, 'Provided API Key or secret is in invalid Format'
-            elif 'EAPI:Invalid key':
+            elif 'EAPI:Invalid key' in error:
                 return False, 'Provided API Key is invalid'
             else:
                 raise


### PR DESCRIPTION
Show proper error if a kraken or binance api key validation fails due to an invalid key having been provided.

fix #99 