### PR TITLE
Fix race condition with fiat exchange rate

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :bug: `86` Fixed race condition at startup that could result in the banks balance displaying as NaN.
 * :bug: `103` After removing an exchange's API key the new api key/secret input form is now properly re-enabled 
 * :bug: `99` Show proper error if kraken or binance api key validation fails due to an invalid key having been provided.
 

--- a/ui/userunlock.js
+++ b/ui/userunlock.js
@@ -162,7 +162,7 @@ function unlock_user(username, password, create_true, sync_approval, api_key, ap
             return unlock_async(username, password, create_true, sync_approval, api_key, api_secret).done(
                 function (response) {
                     let db_settings = response['settings'];
-                    if (!'main_currency' in db_settings) {
+                    if (!('main_currency' in db_settings)) {
                         self.setType('red');
                         self.setTitle('Sign In Failed');
                         self.setContentAppend('<div>main_currency not returned from db_settings</div>');

--- a/ui/utils.js
+++ b/ui/utils.js
@@ -262,6 +262,5 @@ module.exports = function() {
     this.suggest_element = suggest_element;
     this.unsuggest_element = unsuggest_element;
     this.suggest_element_until_click = suggest_element_until_click;
-    this.get_fiat_exchange_rates = get_fiat_exchange_rates;
     this.iterate_saved_balances = iterate_saved_balances;
 };

--- a/ui/utils.js
+++ b/ui/utils.js
@@ -221,31 +221,6 @@ function get_total_asssets_value(asset_dict) {
     return value;
 }
 
-function get_fiat_exchange_rates(currencies) {
-    client.invoke("get_fiat_exchange_rates", currencies, (error, res) => {
-        if (error || res == null) {
-            showError('Connectivity Error', 'Failed to acquire fiat to USD exchange rates: ' + error);
-            return;
-        }
-        console.log("get_fiat_exchange_rates for " + currencies + " returned okay");
-        let rates = res['exchange_rates'];
-        for (let asset in rates) {
-            if(rates.hasOwnProperty(asset)) {
-                settings.usd_to_fiat_exchange_rates[asset] = parseFloat(rates[asset]);
-            }
-        }
-
-        // something noticed is that if a zero rpc call from node to python happens
-        // within very close proximity to another one with the same function then
-        // it's very possible one will timeout with heartbear error. That is why
-        // we call the full exchange rate update here after we get the main
-        // currency exchange rate
-        if (currencies) {
-            get_fiat_exchange_rates(); // for all currencies
-        }
-    });
-}
-
 function* iterate_saved_balances() {
     let saved_balances = total_balances_get();
     for (var location in saved_balances) {


### PR DESCRIPTION
Fix #86

There was a race condition between starting the query of the fiat exchange rate
and actually using it to display balances in the UI. Since the banks/fiat
balance is the first to appear as it's just a DB read, whenever the remote fiat
exchange rates query was too slow, multiplying a number by NaN resulted in Nan.