### PR TITLE
Switch to python 3.7 in the CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@
 os: linux
 language: python
 python:
-  - 3.6
+  - 3.7
 env:
   global:
   - GETH_URL_LINUX='https://gethstore.blob.core.windows.net/builds/geth-linux-amd64-1.8.13-225171a4.tar.gz'
@@ -14,10 +14,12 @@ matrix:
   include:
   - os: osx
     language: generic
-    env: INSTALL_TYPE=macpython VERSION=3.6 VENV=venv
+    env: INSTALL_TYPE=macpython VERSION=3.7 VENV=venv
   - os: linux
     language: python
-    python: '3.6'
+    python: '3.7'
+    dist: xenial
+    sudo: true
 
 cache:
   pip: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -56,12 +56,12 @@ script:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then source terryfy/test_tools.sh; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then python -m pytest rotkehlchen; fi
   - if [[ "$TRAVIS_OS_NAME" != "osx" ]]; then coverage run --source rotkehlchen/ -m pytest --travis-fold=always $TEST_TYPE; fi
-  - npm config set python python2.7
+  # - npm config set python python2.7
   # If we add the specific electron runtime compile in OSX fails with an error
   # that looks like this: https://www.npmjs.com/package/nan#compiling-against-nodejs-012-on-osx
   # - npm install --runtime=electron --target=1.8.4
-  - npm install
-  - PYTHON=/usr/bin/python2.7 ./node_modules/.bin/electron-rebuild
+  - npm install --verbose
+  # - PYTHON=/usr/bin/python2.7 ./node_modules/.bin/electron-rebuild
   - npm test
 
 before_deploy:

--- a/.travis/before_install.sh
+++ b/.travis/before_install.sh
@@ -8,7 +8,7 @@ set -x
 
 if [[ "${TRAVIS_OS_NAME}" == "linux" ]]; then
     apt-get update
-    apt-get install -y libsqlcipher-dev libzmq3 libzmq3-dev
+    apt-get install -y libsqlcipher-dev libzmq5 libzmq3-dev
     sudo ldconfig
 else
     brew update && brew install sqlcipher

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
         "spectron": "^3.8.0"
     },
     "scripts": {
-        "test": "mocha ui/tests/",
+        "test": "mocha --full-trace ui/tests/",
         "start": "electron ."
     }
 }

--- a/rotkehlchen/fval.py
+++ b/rotkehlchen/fval.py
@@ -1,5 +1,5 @@
 from decimal import Decimal, InvalidOperation
-from typing import Union, Optional, NoReturn
+from typing import Union
 
 
 # Here even though we got __future__ annotations using FVal does not seem to work


### PR DESCRIPTION
During work on https://github.com/rotkehlchenio/rotkehlchen/pull/120, adding the `from __future__ import annotations` call took me out on a tangent trying to make the CI work with python 3.7.

Turns out it's a bigger task than I want to handle right now (requires xenial and for some reason mocha tests fail at xenial). So moving the work here to a different branch so #120 can proceed on its own.