### PR TITLE
Remove unused code from packaging

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,7 +6,7 @@ Changelog
 
 * :feature: `95` Add a UI widget to display the last time the balance data was saved in the DB.
 * :bug: `126` Refuse to generate a new tax report if one is in progress and also clean previous report before generating a new one.
-* :bug: `123` Return USD ad default main currency if DB is new
+* :bug: `123` Return USD as default main currency if DB is new
 * :bug: `101` Catch the web3 exception if using a local client with an out of sync chain and report a proper error in the UI
 * :bug: `86` Fixed race condition at startup that could result in the banks balance displaying as NaN.
 * :bug: `103` After removing an exchange's API key the new api key/secret input form is now properly re-enabled 

--- a/package.sh
+++ b/package.sh
@@ -76,38 +76,12 @@ if [[ $? -ne 0 ]]; then
 fi
 
 NAME="rotkehlchen-${PLATFORM}-${ARCH}"
-# Ugly hack to include zmq lib in the distribution. TODO: Is there a better solution?
-# Step 1: Copy the library in the directory
-# Step 2: Create a wrapper script executable for both distros which points
-#         the LD_LIBRARY_PATH to the current directory
-if [[ $PLATFORM == "darwin" ]]; then
-    # ZMQLIBPATH=`otool -l ./rotkehlchen-darwin-x64/rotkehlchen.app/Contents/Resources/app/node_modules/zeromq/build/Release/zmq.node | grep zmq | awk '/ / { print $2 }'`
-    # cp $ZMQLIBPATH $NAME/
-    # if [[ $? -ne 0 ]]; then
-    # 	echo "package.sh - ERROR: copying libzmq step failed"
-    # 	exit 1
-    # fi
 
-    # The above seems to no longer be required. The final executable does not even depend on libzmq
-    echo "noop"
-else
-    # ZMQLIBPATH=`ldd ./rotkehlchen-linux-x64/resources/app/node_modules/zeromq/build/Release/zmq.node | grep libzmq | awk '/ => / { print $3 }'`
-    # cp $ZMQLIBPATH $NAME/
-    # if [[ $? -ne 0 ]]; then
-    # 	echo "package.sh - ERROR: copying libzmq step failed"
-    # 	exit 1
-    # fi
-    # PGMLIBPATH=`ldd $ZMQLIBPATH | grep libpgm | awk '/ => / { print $3 }'`
-    # cp $PGMLIBPATH $NAME/
-    # if [[ $? -ne 0 ]]; then
-    # 	echo "package.sh - ERROR: copying libpgm step failed"
-    # 	exit 1
-    # fi
-
-    # The above seems to no longer be required. The final executable does not even depend on libzmq
+if [[ $PLATFORM == "linux" ]]; then
     mv $NAME/rotkehlchen $NAME/unwrapped_executable
 fi
-    cp tools/scripts/wrapper_script.sh $NAME/rotkehlchen
+
+cp tools/scripts/wrapper_script.sh $NAME/rotkehlchen
 
 
 # Now try to zip the created bundle

--- a/tools/scripts/wrapper_script.sh
+++ b/tools/scripts/wrapper_script.sh
@@ -12,20 +12,9 @@ done
 SCRIPT_DIR="$( cd -P "$( dirname "$FILE_SOURCE" )" && pwd )"
 
 
+# This is a remnant from when we had different code during wrapping that prepared the LD_PATH
 if [[ "$OSTYPE" == "linux-gnu" ]]; then
-    # TODO: Add this check also for OSX
-    # LDD_RESULT=`LD_LIBRARY_PATH=$SCRIPT_DIR ldd $SCRIPT_DIR/resources/app/node_modules/zmq/bin/*/zmq.node | grep "not found" | awk '/ => / {print $1 }'`
-    # if [[ $LDD_RESULT != '' ]]; then
-    # 	echo "Failed to start Rotkehlchen. Dynamic library '$LDD_RESULT' not found";
-    # 	exit 1
-    # fi
-    # LD_LIBRARY_PATH=$SCRIPT_DIR $SCRIPT_DIR/unwrapped_executable
-
-    # The above seems to no longer be required
     $SCRIPT_DIR/unwrapped_executable
 else
-    # DYLD_FALLBACK_LIBRARY_PATH=$SCRIPT_DIR $SCRIPT_DIR/rotkehlchen.app/Contents/MacOS/rotkehlchen
-
-    # The above seems to no longer be required
     $SCRIPT_DIR/rotkehlchen.app/Contents/MacOS/rotkehlchen
 fi


### PR DESCRIPTION
In the past, our node_modules depended on a module called `zmq`. Now this module
is named `zeromq` and the executable generated by the electron packager which
uses `zmq.node` no longer depends on `libzmq`.

In the past we had code that tried to find the specific libzmq and for linux
libpgm that was used and copied it inside the generated bundle. Then the wrapper
script also set the `LD_PATH`.

Since the change of requirements this seems to no longer be required.