### PR TITLE
Fix regex handling on Windows.

### DIFF
--- a/rotkehlchen/history.py
+++ b/rotkehlchen/history.py
@@ -228,6 +228,7 @@ class PriceHistorian(object):
 
         # Check the data folder and remember the filenames of any cached history
         prefix = os.path.join(self.data_directory, 'price_history_')
+        prefix = prefix.replace('\\', '\\\\')
         regex = re.compile(prefix + '(.*)\\.json')
         files_list = glob.glob(prefix + '*.json')
 


### PR DESCRIPTION
Replace \ with \\ to avoid 'incomplete escape' regex error.

The change is safe as *nix paths do not use backslashes.

Refs: https://github.com/rotkehlchenio/rotkehlchen/issues/28