### PR TITLE
Use gender neutral language to refer to users

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ If you have never created an account before press "Create New Account". Provide 
 
 If you already have an account just write the name and the password here.
 
-All accounts are created in the rotkehlchen directory which is located in: `$HOME/.rotkehlchen`. Each user has his own subdirectory.
+All accounts are created in the rotkehlchen directory which is located in: `$HOME/.rotkehlchen`. Each user has their own subdirectory.
 
 ### Changing the Profit Currency
 

--- a/rotkehlchen/data_handler.py
+++ b/rotkehlchen/data_handler.py
@@ -130,7 +130,7 @@ class DataHandler(object):
             if not os.path.exists(os.path.join(user_data_dir, 'rotkehlchen.db')):
                 # This is bad. User directory exists but database is missing.
                 # Make a backup of the directory that user should probably remove
-                # on his own. At the same time delete the directory so that a new
+                # on their own. At the same time delete the directory so that a new
                 # user account can be created
                 shutil.move(
                     user_data_dir,


### PR DESCRIPTION
I noticed the README used masculine pronouns to refer to users, and figured I'd fix it while I waited for the release to download from GitHub 🤷‍♂️