### PR TITLE
Properly handle errors in asynchronous greenlets

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,11 +2,12 @@
 Changelog
 =========
 
-* :bug:`155` Check if the local ethereum node is synced before querying balances from it
-* :feature:`153` Add a ``version`` command to display the rotkehlchen version
-* :bug:`159` Gracefully exit if an invalid argument is provided
+* :bug:`163` Properly handle errors in the tax report calculation and in other asynchronous tasks.
+* :bug:`155` Check if the local ethereum node is synced before querying balances from it.
+* :feature:`153` Add a ``version`` command to display the rotkehlchen version.
+* :bug:`159` Gracefully exit if an invalid argument is provided.
 * :bug:`151` If an asset stored at Bittrex does not have a BTC market rotkehlchen no longer crashes.
-* :feature:`148` Add icons for all tokens to the UI
+* :feature:`148` Add icons for all tokens to the UI.
 * :feature:`74` Add experimental support for Bitmex. Supporting only simple balance query for now.
 * :bug:`135` Fix bug in converting binance sell trades to the common rotkehlchen format
 * :bug:`140` Don't log an error if the manual margin file is not found

--- a/ui/taxreport.js
+++ b/ui/taxreport.js
@@ -111,8 +111,6 @@ function show_float_or_empty(data) {
 }
 
 function create_taxreport_overview(results) {
-    $('#tax_report_loading').remove();
-
     let data = [];
     for (var result in results) {
         if(results.hasOwnProperty(result)) {
@@ -202,6 +200,8 @@ function create_taxreport_details(all_events) {
 
 function init_taxreport() {
     monitor_add_callback('process_trade_history', function (result) {
+        $('#tax_report_loading').remove();
+
         if ('error' in result) {
             showError(
                 'Trade History Query Error',


### PR DESCRIPTION
If an error occurs in a child greenlet running asynchronously, such as the one that creates the tax report, properly catch it, return information about the error to the user and log it as an error.

Fixed #163 
