### PR TITLE
Issue #186: hooks up enter keypress

### DIFF
--- a/ui/userunlock.ts
+++ b/ui/userunlock.ts
@@ -128,10 +128,11 @@ export function prompt_sign_in() {
         },
         onContentReady: () => {
             const $content = $(document);
-            $content.find('form').on('submit', function (e: JQuery.Event) {
-                // if the user submits the form by pressing enter in the field.
-                e.preventDefault();
-                $(e.target).trigger('click'); // reference the button and click it
+            $content.find('#password_entry').on('keypress', function(e) {
+                if (e.keyCode === 13) { // enter key
+                    e.preventDefault();
+                    $content.find('button:contains("Sign In")').trigger('click');
+                }
             });
         }
     });


### PR DESCRIPTION
This resolves Issue #186 

There was existing code that was attempting to do this but didn't function.

this is slightly ugly as there's no way in jquery-confirm to set the id of the buttons. As a result, we need to grab the button to submit by the text of the button. If jquery-confirm adds this functionality it could be upgraded to make this cleaner