### PR TITLE
Handle setting tax_free_after_period to None

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :bug:`197` Rotkehlchen no longer crashes at restart if a "No" tax_free_period is given
 * :bug:`185` Ethereum node connection indicator should always properly indicate the connection status to the underlying ethereum node
 * :bug:`184` If Rotkehlchen brand name in top left is clicked, open browser to rotkehlchen.io instead of showing the sign-in popup
 * :bug:`187` Exchange balance tables no longer become unresponsive if visited multiple times.
@@ -30,7 +31,7 @@ Changelog
 * :bug:`123` Return USD as default main currency if DB is new
 * :bug:`101` Catch the web3 exception if using a local client with an out of sync chain and report a proper error in the UI
 * :bug:`86` Fixed race condition at startup that could result in the banks balance displaying as NaN.
-* :bug:`103` After removing an exchange's API key the new api key/secret input form is now properly re-enabled 
+* :bug:`103` After removing an exchange's API key the new api key/secret input form is now properly re-enabled
 * :bug:`99` Show proper error if kraken or binance api key validation fails due to an invalid key having been provided.
 
 * :release:`0.3.1 <2018-06-25>`

--- a/rotkehlchen/db/dbhandler.py
+++ b/rotkehlchen/db/dbhandler.py
@@ -247,7 +247,7 @@ class DBHandler(object):
             elif q[0] == 'ui_floating_precision':
                 settings['ui_floating_precision'] = int(q[1])
             elif q[0] == 'taxfree_after_period':
-                settings['taxfree_after_period'] = int(q[1])
+                settings['taxfree_after_period'] = int(q[1]) if q[1] else None
             elif q[0] == 'balance_save_frequency':
                 settings['balance_save_frequency'] = int(q[1])
             elif q[0] == 'include_gas_costs':


### PR DESCRIPTION
I stumbled upon this bug when working on adding the gas costs option to the Account settings.  I managed to break my login account because of the `tax free after period` setting.  It looks like when the option is set to `No`, it sends a null value to the backend and the database code doesn't handle getting a `None` value for this setting when looking up the settings again.

This little hotfix makes it so the settings code can handle the `None` and the front-end will correctly display Yes or No when this option is set.

**Steps to Reproduce:**
- Create a new account
- Go to the Accounting Settings screen
- Change the tax free after period setting to `No`
<img width="636" alt="screen shot 2018-10-12 at 7 17 41 pm" src="https://user-images.githubusercontent.com/7581276/46899788-d8da3d00-ce65-11e8-9a16-e2648868fe2c.png">

- Hit the `Set` button and save the settings to the database.

- Everything will be fine at first but the next time you try to log in, you get this error:
<img width="395" alt="screen shot 2018-10-12 at 6 49 38 pm" src="https://user-images.githubusercontent.com/7581276/46899794-feffdd00-ce65-11e8-9a8c-b64c89bc527f.png">
