### PR TITLE
Fix tax report problems (CSV and poloniex settlement loss calculation)

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,8 @@
 Changelog
 =========
 
+* :bug:`219` Poloniex BTC settlement loss calculation is now correct.
+* :bug:`217` Tax report CSV exports should now agree with the app report.
 * :bug:`211` Handle the BCHSV fork in Kraken properly.
 
 * :release:`0.5.0 <2018-11-10>`

--- a/rotkehlchen/accounting/accountant.py
+++ b/rotkehlchen/accounting/accountant.py
@@ -186,6 +186,9 @@ class Accountant(object):
             exchange: str,
             fee: FVal,
     ) -> None:
+        if timestamp < self.start_ts:
+            return
+
         rate = self.get_rate_in_profit_currency(asset, timestamp)
         cost = fee * rate
         self.asset_movement_fees += cost
@@ -212,6 +215,8 @@ class Accountant(object):
 
     def account_for_gas_costs(self, transaction: EthereumTransaction) -> None:
         if not self.include_gas_costs:
+            return
+        if transaction.timestamp < self.start_ts:
             return
 
         if transaction.gas_price == -1:
@@ -303,6 +308,7 @@ class Accountant(object):
         )
         self.events.reset(start_ts, end_ts)
         self.last_gas_price = FVal("2000000000")
+        self.start_ts = start_ts
         self.eth_transactions_gas_costs = FVal(0)
         self.asset_movement_fees = FVal(0)
         self.csvexporter.reset_csv_lists()

--- a/rotkehlchen/accounting/accountant.py
+++ b/rotkehlchen/accounting/accountant.py
@@ -495,7 +495,7 @@ class Accountant(object):
             gain_in_profit_currency = selling_rate * trade.amount
             self.events.add_sell(
                 selling_asset=selling_asset,
-                selling_amount=trade.cost,
+                selling_amount=trade.amount,
                 receiving_asset=None,
                 receiving_amount=None,
                 gain_in_profit_currency=gain_in_profit_currency,

--- a/rotkehlchen/accounting/events.py
+++ b/rotkehlchen/accounting/events.py
@@ -271,18 +271,19 @@ class TaxableEvents(object):
             timestamp=timestamp,
         )
 
-        self.csv_exporter.add_buy(
-            bought_asset=bought_asset,
-            rate=buy_rate,
-            fee_cost=fee_cost,
-            amount=bought_amount,
-            gross_cost=gross_cost,
-            cost=cost,
-            paid_with_asset=paid_with_asset,
-            paid_with_asset_rate=paid_with_asset_rate,
-            timestamp=timestamp,
-            is_virtual=is_virtual,
-        )
+        if timestamp >= self.query_start_ts:
+            self.csv_exporter.add_buy(
+                bought_asset=bought_asset,
+                rate=buy_rate,
+                fee_cost=fee_cost,
+                amount=bought_amount,
+                gross_cost=gross_cost,
+                cost=cost,
+                paid_with_asset=paid_with_asset,
+                paid_with_asset_rate=paid_with_asset_rate,
+                timestamp=timestamp,
+                is_virtual=is_virtual,
+            )
 
     def add_sell_and_corresponding_buy(
             self,
@@ -440,6 +441,15 @@ class TaxableEvents(object):
             if loan_settlement:
                 # If it's a loan settlement we are charged both the fee and the gain
                 settlement_loss = gain_in_profit_currency + total_fee_in_profit_currency
+                expected = rate_in_profit_currency * selling_amount + total_fee_in_profit_currency
+                msg = (
+                    f'Expected settlement loss mismatch. rate_in_profit_currency'
+                    f' ({rate_in_profit_currency}) * selling_amount'
+                    f' ({selling_amount}) + total_fee_in_profit_currency'
+                    f' ({total_fee_in_profit_currency}) != settlement_loss '
+                    f'({settlement_loss})'
+                )
+                assert expected == settlement_loss, msg
                 self.settlement_losses += settlement_loss
                 log.debug(
                     'Loan Settlement Loss',


### PR DESCRIPTION
- Fix loss calculation of poloniex BTC settlement force sells (#219)
- All tax report CSV exports should now agree with the app report (#217)
- Generating a CSV report will now no longer contain entries before the starting query timestamp.