### PR TITLE
Use promise-retry in UI tests to fix flakiness

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1156,6 +1156,12 @@
             "integrity": "sha1-QWgTO0K7BcOKNbGuQ5fIKYqzaeA=",
             "dev": true
         },
+        "err-code": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/err-code/-/err-code-1.1.2.tgz",
+            "integrity": "sha1-BuARbTAo9q70gGhJ6w6mp0iuaWA=",
+            "dev": true
+        },
         "error-ex": {
             "version": "1.3.2",
             "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
@@ -2529,6 +2535,16 @@
                 "through2": "~0.2.3"
             }
         },
+        "promise-retry": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/promise-retry/-/promise-retry-1.1.1.tgz",
+            "integrity": "sha1-ZznpaOMFHaIM5kl/srUPaRHfPW0=",
+            "dev": true,
+            "requires": {
+                "err-code": "^1.0.0",
+                "retry": "^0.10.0"
+            }
+        },
         "psl": {
             "version": "1.1.29",
             "resolved": "https://registry.npmjs.org/psl/-/psl-1.1.29.tgz",
@@ -2715,6 +2731,12 @@
                 "onetime": "^2.0.0",
                 "signal-exit": "^3.0.2"
             }
+        },
+        "retry": {
+            "version": "0.10.1",
+            "resolved": "https://registry.npmjs.org/retry/-/retry-0.10.1.tgz",
+            "integrity": "sha1-52OI0heZLCUnUCQdPTlW/tmNj/Q=",
+            "dev": true
         },
         "rgb2hex": {
             "version": "0.1.9",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
         "ts-node": "7.0.1",
         "tslint": "5.11.0",
         "tslint-eslint-rules": "5.4.0",
-        "typescript": "3.2.1"
+        "typescript": "3.2.1",
+        "promise-retry": "1.1.1"
     },
     "scripts": {
         "build": "rimraf ui/dist && tsc",

--- a/ui/tests/common.ts
+++ b/ui/tests/common.ts
@@ -1,6 +1,7 @@
 import {Application, SpectronClient} from 'spectron';
 import * as electron from 'electron';
 import * as path from 'path';
+const retry = require('promise-retry');
 
 export const GLOBAL_TIMEOUT = 120_000;
 export const METHOD_TIMEOUT = 40_000;
@@ -58,16 +59,24 @@ export async function navigateTo(client: SpectronClient, elementId: string) {
 
 export async function closeAddYourSettingsPopup(client: SpectronClient) {
     await client.waitUntilTextExists('.jconfirm-title', 'Add your settings', METHOD_TIMEOUT);
-    await client.click('.jconfirm-buttons>button');
+    await retry( async() => {
+        client.click('.jconfirm-buttons>button');
+    });
 }
 
 export async function logout(client: SpectronClient) {
-    await client.click('#user-dropdown');
+    await retry( async() => {
+        client.click('#user-dropdown');
+    });
     await client.waitForVisible('#logout_button', METHOD_TIMEOUT);
-    await client.click('#logout_button');
+    await retry( async() => {
+        client.click('#logout_button');
+    });
 
     await client.waitForVisible('.jconfirm', METHOD_TIMEOUT);
-    await client.click('.jconfirm-buttons>button');
+    await retry( async() => {
+        client.click('.jconfirm-buttons>button');
+    });
     await client.waitUntilTextExists('.jconfirm-title', 'Sign In', METHOD_TIMEOUT);
 }
 
@@ -78,9 +87,13 @@ export async function login(client: SpectronClient, username: string, password: 
     await client.clearElement('#password_entry');
     await client.addValue('#password_entry', password);
 
-    await client.click('.jconfirm-buttons>button');
+    await retry( async() => {
+        client.click('.jconfirm-buttons>button');
+    });
 
     await client.waitUntilTextExists('.jconfirm-title', 'Successful Sign In', METHOD_TIMEOUT);
-    await client.click('.jconfirm-buttons>button');
+    await retry( async() => {
+        client.click('.jconfirm-buttons>button');
+    });
     await client.waitForVisible('.jconfirm', METHOD_TIMEOUT, true);
 }

--- a/ui/tests/dashboard.spec.ts
+++ b/ui/tests/dashboard.spec.ts
@@ -14,7 +14,7 @@ import * as chaiAsPromised from 'chai-as-promised';
 import {Guid} from './guid';
 import {AccountType, UserSettingsController} from './user_settings_controller';
 
-
+const retry = require('promise-retry');
 chai.should();
 chai.use(chaiAsPromised);
 
@@ -58,7 +58,9 @@ describe('dashboard', function () {
         const apiSecret = process.env.BITTREX_API_SECRET as string;
 
         before(async () => {
-            await navigateTo(client, '#user_settings_button');
+            await retry( async() => {
+                navigateTo(client,  '#user_settings_button');
+            });
             await closeAddYourSettingsPopup(client);
 
             await client.waitForVisible('#blockchain_balances_panel_body', METHOD_TIMEOUT);
@@ -93,6 +95,8 @@ describe('dashboard', function () {
 });
 
 async function navigateToDashboard(client: SpectronClient) {
-    await client.click('#side-menu > li');
-    await client.waitUntilTextExists('.page-header', 'Dashboard', METHOD_TIMEOUT);
+    await retry( async() => {
+        client.click('#side-menu > li');
+        client.waitUntilTextExists('.page-header', 'Dashboard', METHOD_TIMEOUT);
+    });
 }

--- a/ui/tests/settings_general.spec.ts
+++ b/ui/tests/settings_general.spec.ts
@@ -3,6 +3,7 @@ import {createAccount, GLOBAL_TIMEOUT, initialiseSpectron, login, logout, METHOD
 import * as chai from 'chai';
 import * as chaiAsPromised from 'chai-as-promised';
 import {Guid} from './guid';
+const retry = require('promise-retry');
 
 chai.should();
 chai.use(chaiAsPromised);
@@ -36,8 +37,12 @@ describe('general settings', function () {
     });
 
     it('should add wrong port number and get an error', async () => {
-        await client.clearElement('#eth_rpc_port');
-        await client.addValue('#eth_rpc_port', 500000);
+        await retry( async() => {
+            client.clearElement('#eth_rpc_port');
+        });
+        await retry( async() => {
+            client.addValue('#eth_rpc_port', 500000);
+        });
         await client.click('#settingssubmit');
 
         await client.waitUntilTextExists('.jconfirm-title', 'Invalid port number', METHOD_TIMEOUT);
@@ -50,23 +55,43 @@ describe('general settings', function () {
     });
 
     it('should change the general settings and save them', async () => {
-        await client.clearElement('#eth_rpc_port');
-        await client.addValue('#eth_rpc_port', 9001);
+        await retry( async() => {
+            client.clearElement('#eth_rpc_port');
+        });
+        await retry( async() => {
+            client.addValue('#eth_rpc_port', 9001);
+        });
 
-        await client.clearElement('#floating_precision');
-        await client.addValue('#floating_precision', 4);
+        await retry( async() => {
+            client.clearElement('#floating_precision');
+        });
+        await retry( async() => {
+            client.addValue('#floating_precision', 4);
+        });
 
-        await client.clearElement('#balance_save_frequency');
-        await client.addValue('#balance_save_frequency', 48);
+        await retry( async() => {
+            client.clearElement('#balance_save_frequency');
+        });
+        await retry( async() => {
+            client.addValue('#balance_save_frequency', 48);
+        });
 
-        await client.click('#anonymized_logs_input');
+        await retry( async() => {
+            client.click('#anonymized_logs_input');
+        });
 
-        await client.clearElement('#historical_data_start');
-        await client.addValue('#historical_data_start', '03/10/2018');
+        await retry( async() => {
+            client.clearElement('#historical_data_start');
+        });
+        await retry( async() => {
+            client.addValue('#historical_data_start', '03/10/2018');
+        });
 
         await client.selectByValue('#maincurrencyselector', 'JPY');
 
-        await client.click('#settingssubmit');
+        await retry( async() => {
+            client.click('#settingssubmit');
+        });
 
         await client.waitUntilTextExists('.jconfirm-title', 'Success', METHOD_TIMEOUT);
         await client.element('.jconfirm-content > div').getText()
@@ -74,7 +99,9 @@ describe('general settings', function () {
             .eventually
             .contain('Successfully modified settings.');
 
-        await client.click('.jconfirm-buttons > button');
+        await retry( async() => {
+            client.click('.jconfirm-buttons > button');
+        });
         await client.waitForExist('.jconfirm-box', METHOD_TIMEOUT, true);
 
         await logout(client);

--- a/ui/tests/user_settings_controller.ts
+++ b/ui/tests/user_settings_controller.ts
@@ -1,6 +1,6 @@
 import {SpectronClient} from 'spectron';
 import {METHOD_TIMEOUT} from './common';
-
+const retry = require('promise-retry');
 export enum AccountType {
     ETH = 'ETH',
     BTC = 'BTC'
@@ -15,15 +15,19 @@ export class UserSettingsController {
         await this.client.click('#fiat_type_entry');
         await this.client.element('#fiat_type_entry').click('option=USD');
         await this.client.addValue('#fiat_value_entry', amount);
-        await this.client.click('#modify_fiat_button');
+        await retry( async() => {
+            this.client.click('#modify_fiat_button');
+        });
     }
 
     async addAccount(accountType: AccountType, account: string) {
         await this.clearAccountInput();
+        await retry( async() => {
+            this.client.scroll('#crypto_type_entry', 0, 0);
+            this.client.click('#crypto_type_entry');
+            this.client.element('#crypto_type_entry').click(`option=${accountType}`);
+        });
 
-        await this.client.scroll('#crypto_type_entry', 0, 0);
-        await this.client.click('#crypto_type_entry');
-        await this.client.element('#crypto_type_entry').click(`option=${accountType}`);
         await this.client.addValue('#account_entry', account);
         await this.client.click('#add_account_button');
     }
@@ -37,13 +41,17 @@ export class UserSettingsController {
 
     async addExchange(apiKey: string, apiSecret: string) {
         await this.client.scroll('#setup_exchange', 0, 0);
-        await this.client.click('#setup_exchange');
+        await retry( async() => {
+            this.client.click('#setup_exchange');
+        });
         await this.client.element('#setup_exchange').click('option=bittrex');
 
         await this.client.addValue('#api_key_entry', apiKey);
         await this.client.addValue('#api_secret_entry', apiSecret);
 
-        await this.client.click('#setup_exchange_button');
+        await retry( async() => {
+            this.client.click('#setup_exchange_button');
+        });
 
         await this.client.waitForExist('#bittrex_badge', METHOD_TIMEOUT);
     }


### PR DESCRIPTION
[no ci tests]
[ui tests]

Got the idea of introducting promise-retry to address flakiness of UI
tests in Travis from:
https://hackernoon.com/testing-your-frontend-code-part-iii-e2e-testing-e9261b56475

Specifically:

> So why do we retry this, using the promise-retry module? The reason is very important, and we will see the same thing happening in the rest of the test — when we ask the browser to do something, like navigating to a URL, the browser will do it, but asynchronously. D>

> Unfortunately, if you do not retry in this case, it could still work, because the browser is very fast. But try running it in a CI system like Travis, as I did, and you may get a failure, because CI-s are usually slower than your local system.

> And that is why, in E2E tests on the browser, we need to retry our checks.