### PR TITLE
If user is not yet logged in periodic query returns empy result

### DIFF
--- a/rotkehlchen/rotkehlchen.py
+++ b/rotkehlchen/rotkehlchen.py
@@ -46,6 +46,7 @@ class Rotkehlchen(object):
         self.results_cache: ResultCache = dict()
         self.premium = None
         self.connected_exchanges = []
+        self.user_is_logged_in = False
 
         logfilename = None
         if args.logtarget == 'file':
@@ -268,6 +269,7 @@ class Rotkehlchen(object):
             inquirer=self.inquirer,
             ethchain=ethchain,
         )
+        self.user_is_logged_in = True
 
     def logout(self):
         user = self.data.username
@@ -295,6 +297,7 @@ class Rotkehlchen(object):
         self.data.logout()
         self.password = None
 
+        self.user_is_logged_in = False
         log.info(
             'User successfully logged out',
             user=user,
@@ -664,9 +667,11 @@ class Rotkehlchen(object):
     def query_periodic_data(self) -> Dict[str, Union[bool, Timestamp]]:
         """Query for frequently changing data"""
         result = {}
-        result['last_balance_save'] = self.data.db.get_last_balance_save_time()
-        result['eth_node_connection'] = self.blockchain.ethchain.connected
-        result['history_process_current_ts'] = self.accountant.currently_processed_timestamp
+
+        if self.user_is_logged_in:
+            result['last_balance_save'] = self.data.db.get_last_balance_save_time()
+            result['eth_node_connection'] = self.blockchain.ethchain.connected
+            result['history_process_current_ts'] = self.accountant.currently_processed_timestamp
         return result
 
     def shutdown(self):

--- a/rotkehlchen/tests/fixtures/rotkehlchen.py
+++ b/rotkehlchen/tests/fixtures/rotkehlchen.py
@@ -35,4 +35,5 @@ def rotkehlchen_instance(cli_args, username, blockchain, accountant):
     # different to the usual user one
     r.accountant = accountant
     r.blockchain = blockchain
+    r.user_is_logged_in = True
     return r

--- a/rotkehlchen/tests/test_api.py
+++ b/rotkehlchen/tests/test_api.py
@@ -1,5 +1,7 @@
 import pytest
 
+from rotkehlchen.rotkehlchen import Rotkehlchen
+
 
 def test_add_remove_blockchain_account(rotkehlchen_instance):
     """Test for issue 66 https://github.com/rotkehlchenio/rotkehlchen/issues/66"""
@@ -30,7 +32,7 @@ def test_add_remove_eth_tokens(rotkehlchen_instance):
 
 
 def test_periodic_query(rotkehlchen_instance):
-    """Test that periodiq query returns expected dict values"""
+    """Test that periodic query returns expected dict values"""
     result = rotkehlchen_instance.query_periodic_data()
 
     assert len(result) == 3
@@ -40,3 +42,10 @@ def test_periodic_query(rotkehlchen_instance):
         result['eth_node_connection'] is False
     )
     assert result['history_process_current_ts'] == -1
+
+
+def test_periodic_data_before_login_completion(cli_args):
+    """Test that periodic query returns empty list if user is not yet logged in"""
+    rotkehlchen = Rotkehlchen(cli_args)
+    result = rotkehlchen.query_periodic_data()
+    assert len(result) == 0

--- a/ui/utils.ts
+++ b/ui/utils.ts
@@ -39,6 +39,11 @@ let client_auditor: Timer;
  */
 function periodic_client_query() {
     service.query_periodic_data().then(result => {
+        if (Object.keys(result).length === 0) {
+            // an empty object means user is not logged in yet
+            return;
+        }
+
         settings.last_balance_save = result['last_balance_save'];
         update_eth_node_connection_status_ui(result['eth_node_connection']);
         update_tax_report_progress(result['history_process_current_ts']);


### PR DESCRIPTION
This fixes situations like the following:

```
Error at periodic client query: AttributeError: 'NoneType' object has no attribute 'get_last_balance_save_time'
```

where the backend may not have finished the log-in procedure but
periodic query already started and we get an exception in the backend.