### PR TITLE
Cache fiat price queries

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :feature:`92` Cache and have multiple APIs to query for fiat price queries.
 * :feature:`222` Add a progress indicator during the tax report generation.
 * :bug:`134` When rotkehlchen makes too many requests to Binance and gets a 429 response it now backs off and waits a bit.
 * :bug:`241` When incurring margin trade loss the lost asset's available amount is now also reduced.

--- a/rotkehlchen/inquirer.py
+++ b/rotkehlchen/inquirer.py
@@ -7,16 +7,24 @@ from typing import Dict, Iterable, Optional, cast
 
 import requests
 
-from rotkehlchen import typing
 from rotkehlchen.constants import FIAT_CURRENCIES, S_DATACOIN, S_IOTA, S_RDN, S_USD
 from rotkehlchen.errors import RemoteError
 from rotkehlchen.fval import FVal
 from rotkehlchen.logging import RotkehlchenLogsAdapter
+from rotkehlchen.typing import (
+    Asset,
+    EthToken,
+    FiatAsset,
+    FilePath,
+    NonEthTokenBlockchainAsset,
+    Timestamp,
+)
 from rotkehlchen.utils import (
-    query_fiat_pair,
+    request_get_dict,
     retry_calls,
     rlk_jsondumps,
     rlk_jsonloads_dict,
+    ts_now,
     tsToDate,
 )
 
@@ -24,32 +32,20 @@ logger = logging.getLogger(__name__)
 log = RotkehlchenLogsAdapter(logger)
 
 
-def get_fiat_usd_exchange_rates(
-        currencies: Optional[Iterable[typing.FiatAsset]] = None,
-) -> Dict[typing.FiatAsset, FVal]:
-    rates = {S_USD: FVal(1)}
-    if not currencies:
-        currencies = FIAT_CURRENCIES[1:]
-    for currency in currencies:
-        rates[currency] = query_fiat_pair(S_USD, currency)
-
-    return rates
-
-
-def world_to_cryptocompare(asset: typing.Asset) -> typing.Asset:
+def world_to_cryptocompare(asset: Asset) -> Asset:
     # Adjust some ETH tokens to how cryptocompare knows them
     if asset == S_RDN:
         # remove this if cryptocompare changes the symbol
-        asset = cast(typing.EthToken, 'RDN*')
+        asset = cast(EthToken, 'RDN*')
     elif asset == S_DATACOIN:
-        asset = cast(typing.NonEthTokenBlockchainAsset, 'DATA')
+        asset = cast(NonEthTokenBlockchainAsset, 'DATA')
     elif asset == S_IOTA:
-        asset = cast(typing.NonEthTokenBlockchainAsset, 'IOT')
+        asset = cast(NonEthTokenBlockchainAsset, 'IOT')
 
     return asset
 
 
-def query_cryptocompare_for_fiat_price(asset: typing.Asset) -> FVal:
+def query_cryptocompare_for_fiat_price(asset: Asset) -> FVal:
     log.debug('Get usd price from cryptocompare', asset=asset)
     asset = world_to_cryptocompare(asset)
     resp = retry_calls(
@@ -85,7 +81,7 @@ def query_cryptocompare_for_fiat_price(asset: typing.Asset) -> FVal:
 
 
 class Inquirer(object):
-    def __init__(self, data_dir: typing.FilePath, kraken=None):
+    def __init__(self, data_dir: FilePath, kraken=None):
         self.kraken = kraken
         self.session = requests.session()
         self.data_directory = data_dir
@@ -101,7 +97,7 @@ class Inquirer(object):
 
     def query_kraken_for_price(
             self,
-            asset: typing.Asset,
+            asset: Asset,
             asset_btc_price: FVal,
     ) -> FVal:
         if asset == 'BTC':
@@ -110,7 +106,7 @@ class Inquirer(object):
 
     def find_usd_price(
             self,
-            asset: typing.Asset,
+            asset: Asset,
             asset_btc_price: Optional[FVal] = None,
     ) -> FVal:
         if self.kraken and self.kraken.first_connection_made and asset_btc_price is not None:
@@ -120,24 +116,27 @@ class Inquirer(object):
 
         return query_cryptocompare_for_fiat_price(asset)
 
+    def get_fiat_usd_exchange_rates(
+            self,
+            currencies: Optional[Iterable[FiatAsset]] = None,
+    ) -> Dict[FiatAsset, FVal]:
+        rates = {S_USD: FVal(1)}
+        if not currencies:
+            currencies = FIAT_CURRENCIES[1:]
+        for currency in currencies:
+            rates[currency] = self.query_fiat_pair(S_USD, currency)
+        return rates
+
     def query_historical_fiat_exchange_rates(
             self,
-            from_currency: typing.FiatAsset,
-            to_currency: typing.FiatAsset,
-            timestamp: typing.Timestamp,
+            from_currency: FiatAsset,
+            to_currency: FiatAsset,
+            timestamp: Timestamp,
     ) -> Optional[FVal]:
         date = tsToDate(timestamp, formatstr='%Y-%m-%d')
-        if date in self.cached_forex_data:
-            if from_currency in self.cached_forex_data[date]:
-                rate = self.cached_forex_data[date][from_currency].get(to_currency)
-                if rate:
-                    log.debug(
-                        'Got cached forex rate',
-                        from_currency=from_currency,
-                        to_currency=to_currency,
-                        rate=rate,
-                    )
-                return rate
+        rate = self._get_cached_forex_data(date, from_currency, to_currency)
+        if rate:
+            return rate
 
         log.debug(
             'Querying exchangeratesapi',
@@ -182,7 +181,116 @@ class Inquirer(object):
         log.debug('Exchangeratesapi query succesful', rate=rate)
         return rate
 
+    def _save_forex_rate(
+            self,
+            date: str,
+            from_currency: FiatAsset,
+            to_currency: FiatAsset,
+            price: FVal,
+    ):
+        if date not in self.cached_forex_data:
+            self.cached_forex_data[date] = {}
+
+        if from_currency not in self.cached_forex_data[date]:
+            self.cached_forex_data[date][from_currency] = {}
+
+        msg = 'Cached value should not already exist'
+        assert to_currency not in self.cached_forex_data[date][from_currency], msg
+        self.cached_forex_data[date][from_currency][to_currency] = price
+        self.save_historical_forex_data()
+
+    def _get_cached_forex_data(
+            self,
+            date: str,
+            from_currency: FiatAsset,
+            to_currency: FiatAsset,
+    ) -> Optional[FVal]:
+        if date in self.cached_forex_data:
+            if from_currency in self.cached_forex_data[date]:
+                rate = self.cached_forex_data[date][from_currency].get(to_currency)
+                if rate:
+                    log.debug(
+                        'Got cached forex rate',
+                        from_currency=from_currency,
+                        to_currency=to_currency,
+                        rate=rate,
+                    )
+                return rate
+        return None
+
     def save_historical_forex_data(self) -> None:
         filename = os.path.join(self.data_directory, 'price_history_forex.json')
         with open(filename, 'w') as outfile:
             outfile.write(rlk_jsondumps(self.cached_forex_data))
+
+    def _query_currency_converterapi(self, base: FiatAsset, quote: FiatAsset) -> Optional[FVal]:
+        log.debug(
+            'Query free.currencyconverterapi.com fiat pair',
+            base_currency=base,
+            quote_currency=quote,
+        )
+        pair = '{}_{}'.format(base, quote)
+        querystr = 'https://free.currencyconverterapi.com/api/v5/convert?q={}'.format(pair)
+        try:
+            resp = request_get_dict(querystr)
+            return FVal(resp['results'][pair]['val'])
+        except (ValueError, RemoteError, KeyError):
+            log.error(
+                'Querying free.currencyconverterapi.com fiat pair failed',
+                base_currency=base,
+                quote_currency=quote,
+            )
+            return None
+
+    def _query_exchanges_rateapi(self, base: FiatAsset, quote: FiatAsset) -> Optional[FVal]:
+        log.debug(
+            'Querying api.exchangeratesapi.io fiat pair',
+            base_currency=base,
+            quote_currency=quote,
+        )
+        querystr = f'https://api.exchangeratesapi.io/latest?base={base}&symbols={quote}'
+        try:
+            resp = request_get_dict(querystr)
+            return FVal(resp['rates'][quote])
+        except (ValueError, RemoteError, KeyError):
+            log.error(
+                'Querying api.exchangeratesapi.io for fiat pair failed',
+                base_currency=base,
+                quote_currency=quote,
+            )
+            return None
+
+    def query_fiat_pair(self, base: FiatAsset, quote: FiatAsset) -> FVal:
+        if base == quote:
+            return FVal(1.0)
+
+        now = ts_now()
+        date = tsToDate(ts_now(), formatstr='%Y-%m-%d')
+        price = self._get_cached_forex_data(date, base, quote)
+        if price:
+            return price
+
+        price = self._query_currency_converterapi(base, quote)
+        if not price:
+            price = self._query_exchanges_rateapi(base, quote)
+
+        if not price:
+            # Search the cache for any price in the last month
+            for i in range(1, 31):
+                now = Timestamp(now - Timestamp(86401))
+                date = tsToDate(now, formatstr='%Y-%m-%d')
+                price = self._get_cached_forex_data(date, base, quote)
+                if price:
+                    log.debug(
+                        f'Could not query online apis for a fiat price. '
+                        f'Used cached value from {i} days ago.',
+                        base_currency=base,
+                        quote_currency=quote,
+                        price=price,
+                    )
+                    return price
+
+            raise ValueError('Could not find a "{}" price for "{}"'.format(base, quote))
+
+        self._save_forex_rate(date, base, quote, price)
+        return price

--- a/rotkehlchen/server.py
+++ b/rotkehlchen/server.py
@@ -12,7 +12,6 @@ from gevent.lock import Semaphore
 
 from rotkehlchen.args import app_args
 from rotkehlchen.errors import AuthenticationError, PermissionError
-from rotkehlchen.inquirer import get_fiat_usd_exchange_rates
 from rotkehlchen.logging import RotkehlchenLogsAdapter
 from rotkehlchen.rotkehlchen import Rotkehlchen
 from rotkehlchen.utils import pretty_json_dumps, process_result
@@ -135,7 +134,8 @@ class RotkehlchenServer(object):
         return ret
 
     def get_fiat_exchange_rates(self, currencies):
-        res = {'exchange_rates': get_fiat_usd_exchange_rates(currencies)}
+        rates = self.rotkehlchen.inquirer.get_fiat_usd_exchange_rates(currencies)
+        res = {'exchange_rates': rates}
         return process_result(res)
 
     def get_settings(self):

--- a/rotkehlchen/tests/fixtures/accounting.py
+++ b/rotkehlchen/tests/fixtures/accounting.py
@@ -14,9 +14,18 @@ TEST_HISTORY_DATA_START = "01/01/2015"
 
 
 @pytest.fixture
-def accounting_data_dir():
+def use_clean_caching_directory():
+    """If this is set to True then a clean accounting directory will be used."""
+    return False
+
+
+@pytest.fixture
+def accounting_data_dir(use_clean_caching_directory, tmpdir_factory):
     """For accounting we have a dedicated test data dir so that it's easy to
     cache the results of the historic price queries also in Travis"""
+    if use_clean_caching_directory:
+        return tmpdir_factory.mktemp('accounting_data')
+
     home = os.path.expanduser("~")
     if 'TRAVIS' in os.environ:
         data_directory = os.path.join(home, '.cache', '.rotkehlchen-test-dir')
@@ -121,3 +130,8 @@ def accountant(
 @pytest.fixture
 def inquirer(accounting_data_dir):
     return Inquirer(data_dir=accounting_data_dir, kraken=None)
+
+
+@pytest.fixture(scope='session')
+def session_inquirer(session_data_dir):
+    return Inquirer(data_dir=session_data_dir, kraken=None)

--- a/rotkehlchen/tests/fixtures/exchanges/kraken.py
+++ b/rotkehlchen/tests/fixtures/exchanges/kraken.py
@@ -5,6 +5,7 @@ from typing import Dict, List, Optional
 
 import pytest
 
+from rotkehlchen.constants import S_EUR, S_USD
 from rotkehlchen.kraken import KRAKEN_ASSETS, KRAKEN_DELISTED, Kraken
 from rotkehlchen.tests.utils.factories import (
     make_random_b64bytes,
@@ -138,10 +139,11 @@ class MockKraken(Kraken):
 
 
 @pytest.fixture(scope='session')
-def kraken(session_data_dir):
+def kraken(session_data_dir, session_inquirer):
     mock = MockKraken(
         api_key=base64.b64encode(make_random_b64bytes(128)),
         secret=base64.b64encode(make_random_b64bytes(128)),
         user_directory=session_data_dir,
+        usd_eur_price=session_inquirer.query_fiat_pair(S_EUR, S_USD),
     )
     return mock

--- a/rotkehlchen/tests/test_binance.py
+++ b/rotkehlchen/tests/test_binance.py
@@ -9,6 +9,7 @@ from rotkehlchen.binance import Binance, trade_from_binance
 from rotkehlchen.errors import RemoteError
 from rotkehlchen.fval import FVal
 from rotkehlchen.order_formatting import Trade
+from rotkehlchen.tests.utils.mock import MockResponse
 
 
 @pytest.fixture
@@ -148,13 +149,6 @@ exchange_info_mock_text = '''{
 
 
 def test_binance_backoff_after_429(mock_binance):
-    class MockResponse():
-
-        def __init__(self, status_code, text):
-            self.status_code = status_code
-            self.text = text
-            self.url = 'http://someurl.com'
-
     count = 0
 
     def mock_429(url):

--- a/rotkehlchen/tests/test_inquirer.py
+++ b/rotkehlchen/tests/test_inquirer.py
@@ -1,0 +1,72 @@
+from unittest.mock import patch
+
+import pytest
+import requests
+
+from rotkehlchen.fval import FVal
+from rotkehlchen.tests.utils.mock import MockResponse
+from rotkehlchen.utils import ts_now, tsToDate
+
+
+@pytest.mark.parametrize('use_clean_caching_directory', [True])
+def test_query_realtime_price_apis(inquirer):
+    result = inquirer._query_currency_converterapi('USD', 'EUR')
+    assert result and isinstance(result, FVal)
+    result = inquirer._query_exchanges_rateapi('USD', 'GBP')
+    assert result and isinstance(result, FVal)
+    result = inquirer.query_historical_fiat_exchange_rates('USD', 'CNY', 1411603200)
+    assert result == FVal('6.1371932033')
+
+
+@pytest.mark.parametrize('use_clean_caching_directory', [True])
+def test_switching_to_backup_api(inquirer):
+    count = 0
+    original_get = requests.get
+
+    def mock_currency_converter_fail(uri):
+        nonlocal count
+        count += 1
+        if 'currencyconverterapi' in uri:
+            return MockResponse(501, '{"msg": "some error")')
+        return original_get(uri)
+
+    with patch('requests.get', side_effect=mock_currency_converter_fail):
+        result = inquirer.query_fiat_pair('USD', 'EUR')
+        assert result and isinstance(result, FVal)
+        assert count > 1, 'requests.get should have been called more than once'
+
+
+@pytest.mark.parametrize('use_clean_caching_directory', [True])
+def test_caching(inquirer):
+    def mock_currency_converter_api(uri):
+        return MockResponse(200, '{"results": {"USD_EUR": {"val": 1.1543, "id": "USD_EUR"}}}')
+
+    with patch('requests.get', side_effect=mock_currency_converter_api):
+        result = inquirer.query_fiat_pair('USD', 'EUR')
+        assert result == FVal('1.1543')
+
+    # Now outside the mocked response, we should get same value due to caching
+    assert inquirer.query_fiat_pair('USD', 'EUR') == FVal('1.1543')
+
+
+@pytest.mark.parametrize('use_clean_caching_directory', [True])
+def test_fallback_to_cached_values_within_a_month(inquirer):
+    def mock_api_remote_fail(uri):
+        return MockResponse(500, '{"msg": "shit hit the fan"')
+
+    # Get a date 15 days ago and insert a cached entry for EUR JPY then
+    now = ts_now()
+    eurjpy_val = FVal('124.123')
+    date = tsToDate(now - 86400 * 15, formatstr='%Y-%m-%d')
+    inquirer._save_forex_rate(date, 'EUR', 'JPY', eurjpy_val)
+    # Get a date 31 days ago and insert a cache entry for EUR CNY then
+    date = tsToDate(now - 86400 * 31, formatstr='%Y-%m-%d')
+    inquirer._save_forex_rate(date, 'EUR', 'CNY', FVal('7.719'))
+
+    with patch('requests.get', side_effect=mock_api_remote_fail):
+        # We fail to find a response but then go back 15 days and find the cached response
+        result = inquirer.query_fiat_pair('EUR', 'JPY')
+        assert result == eurjpy_val
+        # The cached response for EUR CNY is too old so we will fail here
+        with pytest.raises(ValueError):
+            result = inquirer.query_fiat_pair('EUR', 'CNY')

--- a/rotkehlchen/tests/utils/mock.py
+++ b/rotkehlchen/tests/utils/mock.py
@@ -1,0 +1,5 @@
+class MockResponse():
+    def __init__(self, status_code, text):
+        self.status_code = status_code
+        self.text = text
+        self.url = 'http://someurl.com'

--- a/rotkehlchen/utils.py
+++ b/rotkehlchen/utils.py
@@ -17,7 +17,7 @@ from rotkehlchen.constants import ALL_REMOTES_TIMEOUT, ZERO
 from rotkehlchen.errors import RecoverableRequestError, RemoteError
 from rotkehlchen.fval import FVal
 from rotkehlchen.logging import RotkehlchenLogsAdapter
-from rotkehlchen.typing import Asset, Fee, FiatAsset, FilePath, ResultCache, Timestamp
+from rotkehlchen.typing import Asset, Fee, FilePath, ResultCache, Timestamp
 
 logger = logging.getLogger(__name__)
 log = RotkehlchenLogsAdapter(logger)
@@ -101,39 +101,6 @@ def cache_response_timewise(seconds: int = 600):
 
         return wrapper
     return _cache_response_timewise
-
-
-def query_fiat_pair(base: FiatAsset, quote: FiatAsset) -> FVal:
-    if base == quote:
-        return FVal(1.0)
-
-    log.debug(
-        'Query free.currencyconverterapi.com fiat pair',
-        base_currency=base,
-        quote_currency=quote,
-    )
-    pair = '{}_{}'.format(base, quote)
-    querystr = 'https://free.currencyconverterapi.com/api/v5/convert?q={}'.format(pair)
-    try:
-        resp = request_get_dict(querystr)
-        return FVal(resp['results'][pair]['val'])
-    except (ValueError, RemoteError, KeyError):
-        log.error(
-            'Querying free.currencyconverterapi.com fiat pair failed',
-            base_currency=base,
-            quote_currency=quote,
-        )
-        querystr = f'https://api.exchangeratesapi.io/latest?base={base}&symbols={quote}'
-        try:
-            resp = request_get_dict(querystr)
-            return FVal(resp['rates'][quote])
-        except (ValueError, RemoteError, KeyError):
-            log.error(
-                'Querying api.exchangeratesapi.io for fiat pair failed',
-                base_currency=base,
-                quote_currency=quote,
-            )
-            raise ValueError('Could not find a "{}" price for "{}"'.format(base, quote))
 
 
 def from_wei(wei_value: FVal) -> FVal:


### PR DESCRIPTION
- Moved all fiat price queries to the Inquirer class and made sure
  Inquirer is initialized at start of app

- All fiat price queries are now cached

- If all remote API queries for FIAT prices fails then we check the
  cache up to 30 days in the past to find the most recent cached
  value. If found we return it

- If all else fails we bail.

This fixes #92