### PR TITLE
Trades now exclusively follow BASE_QUOTE convention

### DIFF
--- a/rotkehlchen/accounting/accountant.py
+++ b/rotkehlchen/accounting/accountant.py
@@ -13,12 +13,11 @@ from rotkehlchen.logging import RotkehlchenLogsAdapter
 from rotkehlchen.order_formatting import (
     AssetMovement,
     MarginPosition,
-    Trade,
     trade_get_assets,
     trade_get_other_pair,
 )
 from rotkehlchen.transactions import EthereumTransaction
-from rotkehlchen.typing import Asset, Fee, FiatAsset, FilePath, Timestamp
+from rotkehlchen.typing import Asset, Fee, FiatAsset, FilePath, Timestamp, Trade
 
 logger = logging.getLogger(__name__)
 log = RotkehlchenLogsAdapter(logger)
@@ -477,7 +476,7 @@ class Accountant(object):
         # When you buy, you buy with the cost_currency and receive the other one
         # When you sell, you sell the amount in non-cost_currency and receive
         # costs in cost_currency
-        if trade.type == 'buy':
+        if trade.trade_type == 'buy':
             self.events.add_buy_and_corresponding_sell(
                 bought_asset=trade_get_other_pair(trade, trade.cost_currency),
                 bought_amount=trade.amount,
@@ -487,12 +486,12 @@ class Accountant(object):
                 fee_currency=trade.fee_currency,
                 timestamp=trade.timestamp,
             )
-        elif trade.type == 'sell':
+        elif trade.trade_type == 'sell':
             self.trade_add_to_sell_events(trade, False)
-        elif trade.type == 'settlement_sell':
+        elif trade.trade_type == 'settlement_sell':
             # in poloniex settlements sell some asset to get BTC to repay a loan
             self.trade_add_to_sell_events(trade, True)
-        elif trade.type == 'settlement_buy':
+        elif trade.trade_type == 'settlement_buy':
             # in poloniex settlements you buy some asset with BTC to repay a loan
             # so in essense you sell BTC to repay the loan
             selling_asset = S_BTC
@@ -517,7 +516,7 @@ class Accountant(object):
                 loan_settlement=True,
             )
         else:
-            raise ValueError('Unknown trade type "{}" encountered'.format(trade.type))
+            raise ValueError(f'Unknown trade type "{trade.trade_type}" encountered')
 
         return True, prev_time, count
 

--- a/rotkehlchen/binance.py
+++ b/rotkehlchen/binance.py
@@ -13,7 +13,8 @@ from rotkehlchen.exchange import Exchange
 from rotkehlchen.fval import FVal
 from rotkehlchen.inquirer import Inquirer
 from rotkehlchen.logging import RotkehlchenLogsAdapter
-from rotkehlchen.typing import ApiKey, ApiSecret, FilePath, Timestamp, Trade
+from rotkehlchen.order_formatting import Trade
+from rotkehlchen.typing import ApiKey, ApiSecret, FilePath, Timestamp
 from rotkehlchen.utils import cache_response_timewise, rlk_jsonloads
 
 logger = logging.getLogger(__name__)

--- a/rotkehlchen/binance.py
+++ b/rotkehlchen/binance.py
@@ -7,14 +7,13 @@ from urllib.parse import urlencode
 
 import gevent
 
-from rotkehlchen import typing
 from rotkehlchen.constants import CACHE_RESPONSE_FOR_SECS
 from rotkehlchen.errors import RemoteError
 from rotkehlchen.exchange import Exchange
 from rotkehlchen.fval import FVal
 from rotkehlchen.inquirer import Inquirer
 from rotkehlchen.logging import RotkehlchenLogsAdapter
-from rotkehlchen.order_formatting import Trade
+from rotkehlchen.typing import ApiKey, ApiSecret, FilePath, Timestamp, Trade
 from rotkehlchen.utils import cache_response_timewise, rlk_jsonloads
 
 logger = logging.getLogger(__name__)
@@ -64,10 +63,8 @@ def trade_from_binance(
     else:
         order_type = 'sell'
 
-    cost_currency = quote_asset
     fee_currency = binance_trade['commissionAsset']
     fee = FVal(binance_trade['commission'])
-    cost = rate * amount
 
     log.debug(
         'Processing binance Trade',
@@ -85,15 +82,13 @@ def trade_from_binance(
 
     return Trade(
         timestamp=timestamp,
+        location='binance',
         pair=base_asset + '_' + quote_asset,
-        type=order_type,
+        trade_type=order_type,
+        amount=amount,
         rate=rate,
-        cost=cost,
-        cost_currency=cost_currency,
         fee=fee,
         fee_currency=fee_currency,
-        amount=amount,
-        location='binance',
     )
 
 
@@ -106,10 +101,10 @@ class Binance(Exchange):
     """
     def __init__(
             self,
-            api_key: typing.ApiKey,
-            secret: typing.ApiSecret,
+            api_key: ApiKey,
+            secret: ApiSecret,
             inquirer: Inquirer,
-            data_dir: typing.FilePath,
+            data_dir: FilePath,
             initial_backoff: int = 4,
             backoff_limit: int = 180,
     ):
@@ -275,9 +270,9 @@ class Binance(Exchange):
 
     def query_trade_history(
             self,
-            start_ts: typing.Timestamp,
-            end_ts: typing.Timestamp,
-            end_at_least_ts: typing.Timestamp,
+            start_ts: Timestamp,
+            end_ts: Timestamp,
+            end_at_least_ts: Timestamp,
             markets: Optional[str] = None,
     ) -> List:
         cache = self.check_trades_cache(start_ts, end_at_least_ts)

--- a/rotkehlchen/bittrex.py
+++ b/rotkehlchen/bittrex.py
@@ -12,7 +12,8 @@ from rotkehlchen.exchange import Exchange
 from rotkehlchen.fval import FVal
 from rotkehlchen.inquirer import Inquirer
 from rotkehlchen.logging import RotkehlchenLogsAdapter
-from rotkehlchen.typing import ApiKey, ApiSecret, BlockchainAsset, FilePath, Timestamp, Trade
+from rotkehlchen.order_formatting import Trade, invert_pair
+from rotkehlchen.typing import ApiKey, ApiSecret, BlockchainAsset, FilePath, Timestamp
 from rotkehlchen.utils import (
     cache_response_timewise,
     createTimeStamp,
@@ -77,6 +78,11 @@ def trade_from_bittrex(bittrex_trade: Dict) -> Trade:
         bittrex_pair=bittrex_trade['Exchange'],
         pair=pair,
     )
+
+    # Since in Bittrex the base currency is the cost currency, iow in Bittrex
+    # for BTC_ETH we buy ETH with BTC and sell ETH for BTC, we need to turn it
+    # into the Rotkehlchen way which is following the base/quote approach.
+    pair = invert_pair(pair)
 
     return Trade(
         timestamp=bittrex_trade['TimeStamp'],

--- a/rotkehlchen/data_handler.py
+++ b/rotkehlchen/data_handler.py
@@ -118,7 +118,7 @@ def verify_otctrade_data(
         return None, 'Trade type can only be buy or sell'
 
     trade = typing.Trade(
-        time=timestamp,
+        timestamp=timestamp,
         location='external',
         pair=cast(str, pair),
         trade_type=trade_type,

--- a/rotkehlchen/db/dbhandler.py
+++ b/rotkehlchen/db/dbhandler.py
@@ -739,7 +739,7 @@ class DBHandler(object):
             '  notes)'
             'VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)',
             (
-                trade.time,
+                trade.timestamp,
                 trade.location,
                 trade.pair,
                 trade.trade_type,
@@ -773,7 +773,7 @@ class DBHandler(object):
             '  notes=? '
             'WHERE id=?',
             (
-                trade.time,
+                trade.timestamp,
                 trade.location,
                 trade.pair,
                 trade.trade_type,

--- a/rotkehlchen/db/dbhandler.py
+++ b/rotkehlchen/db/dbhandler.py
@@ -16,6 +16,7 @@ from rotkehlchen.datatyping import BalancesData, DBSettings, ExternalTrade
 from rotkehlchen.errors import AuthenticationError, InputError
 from rotkehlchen.fval import FVal
 from rotkehlchen.logging import RotkehlchenLogsAdapter
+from rotkehlchen.order_formatting import Trade
 from rotkehlchen.typing import (
     ApiKey,
     ApiSecret,
@@ -28,7 +29,6 @@ from rotkehlchen.typing import (
     FilePath,
     NonEthTokenBlockchainAsset,
     Timestamp,
-    Trade,
 )
 from rotkehlchen.utils import rlk_jsondumps, rlk_jsonloads_dict, ts_now
 
@@ -833,7 +833,6 @@ class DBHandler(object):
         for result in results:
             trades.append({
                 'id': result[0],
-                # At the moment all trades have "timestamp" and not time
                 'timestamp': result[1],
                 'location': result[2],
                 'pair': result[3],

--- a/rotkehlchen/errors.py
+++ b/rotkehlchen/errors.py
@@ -18,14 +18,6 @@ class RecoverableRequestError(Exception):
         return 'While querying {} got error: "{}"'.format(self.exchange, self.err)
 
 
-class CorruptData(Exception):
-    def __init__(self, err):
-        self.err = err
-
-    def __str__(self):
-        return self.err
-
-
 class InputError(Exception):
     pass
 

--- a/rotkehlchen/poloniex.py
+++ b/rotkehlchen/poloniex.py
@@ -16,8 +16,8 @@ from rotkehlchen.exchange import Exchange
 from rotkehlchen.fval import FVal
 from rotkehlchen.inquirer import Inquirer
 from rotkehlchen.logging import RotkehlchenLogsAdapter
-from rotkehlchen.order_formatting import AssetMovement
-from rotkehlchen.typing import ApiKey, ApiSecret, BlockchainAsset, FilePath, Timestamp, Trade
+from rotkehlchen.order_formatting import AssetMovement, Trade, invert_pair
+from rotkehlchen.typing import ApiKey, ApiSecret, BlockchainAsset, FilePath, Timestamp
 from rotkehlchen.utils import (
     cache_response_timewise,
     createTimeStamp,
@@ -72,6 +72,10 @@ def trade_from_poloniex(poloniex_trade, pair):
         rate=rate,
     )
 
+    # Since in Poloniex the base currency is the cost currency, iow in poloniex
+    # for BTC_ETH we buy ETH with BTC and sell ETH for BTC, we need to turn it
+    # into the Rotkehlchen way which is following the base/quote approach.
+    pair = invert_pair(pair)
     return Trade(
         timestamp=timestamp,
         location='poloniex',

--- a/rotkehlchen/tests/test_accounting.py
+++ b/rotkehlchen/tests/test_accounting.py
@@ -1,6 +1,5 @@
 import pytest
 
-from rotkehlchen.errors import CorruptData
 from rotkehlchen.fval import FVal
 from rotkehlchen.order_formatting import MarginPosition
 from rotkehlchen.tests.utils.accounting import accounting_history_process
@@ -15,8 +14,6 @@ history1 = [
         "pair": "BTC_EUR",
         "type": "buy",
         "rate": 268.678317859,
-        "cost": 22031.6220644,
-        "cost_currency": "EUR",
         "fee": 0,
         "fee_currency": "BTC",
         "amount": 82,
@@ -26,30 +23,24 @@ history1 = [
         "pair": "ETH_EUR",
         "type": "buy",
         "rate": 0.2315893,
-        "cost": 335.804485,
-        "cost_currency": "EUR",
         "fee": 0,
         "fee_currency": "ETH",
         "amount": 1450,
         "location": "external",
     }, {
         "timestamp": 1473505138,  # cryptocompare hourly BTC/EUR price: 556.435
-        "pair": "BTC_ETH",  # cryptocompare hourly ETH/EUR price: 10.365
+        "pair": "ETH_BTC",  # cryptocompare hourly ETH/EUR price: 10.365
         "type": "buy",  # Buy ETH with BTC
         "rate": 0.01858275,
-        "cost": 0.9291375,
-        "cost_currency": "BTC",
         "fee": 0.06999999999999999,
         "fee_currency": "ETH",
         "amount": 50.0,
         "location": "poloniex",
     }, {
         "timestamp": 1475042230,  # cryptocompare hourly BTC/EUR price: 537.805
-        "pair": "BTC_ETH",  # cryptocompare hourly ETH/EUR price: 11.925
+        "pair": "ETH_BTC",  # cryptocompare hourly ETH/EUR price: 11.925
         "type": "sell",  # Sell ETH for BTC
         "rate": 0.02209898,
-        "cost": 0.5524745,
-        "cost_currency": "BTC",
         "fee": 0.00082871175,
         "fee_currency": "BTC",
         "amount": 25.0,
@@ -65,57 +56,6 @@ def test_simple_accounting(accountant):
     assert accountant.taxable_trade_pl.is_close("557.528104903")
 
 
-bad_history1 = [
-    {
-        "timestamp": 1446979735,
-        "pair": "BTC_EUR",
-        "type": "buy",
-        "rate": 268.678317859,
-        "cost": 1131.6220644,
-        "cost_currency": "EUR",
-        "fee": 0,
-        "fee_currency": "BTC",
-        "amount": 82,
-        "location": "external",
-    },
-]
-
-bad_history2 = [
-    {
-        "timestamp": 1446979735,
-        "pair": "BTC_EUR",
-        "type": "buy",
-        "rate": 268.678317859,
-        "cost": 22031.6220644,
-        "cost_currency": "EUR",
-        "fee": 0,
-        "fee_currency": "BTC",
-        "amount": 82,
-        "location": "external",
-    }, {
-        "timestamp": 1475042230,
-        "pair": "BTC_ETH",
-        "type": "sell",
-        "rate": 0.02209898,
-        "cost": 0.1524745,
-        "cost_currency": "BTC",
-        "fee": 0.00082871175,
-        "fee_currency": "BTC",
-        "amount": 25.0,
-        "location": "poloniex",
-    },
-]
-
-
-@pytest.mark.parametrize('mocked_price_queries', [prices])
-def test_mismatch_in_amount_rate_and_cost(accountant):
-    with pytest.raises(CorruptData):
-        accounting_history_process(accountant, 1436979735, 1495751688, bad_history1)
-
-    with pytest.raises(CorruptData):
-        accounting_history_process(accountant, 1436979735, 1495751688, bad_history2)
-
-
 @pytest.mark.parametrize('mocked_price_queries', [prices])
 def test_selling_crypto_bought_with_crypto(accountant):
     history = [{
@@ -123,19 +63,15 @@ def test_selling_crypto_bought_with_crypto(accountant):
         "pair": "BTC_EUR",
         "type": "buy",
         "rate": 268.678317859,
-        "cost": 22031.6220644,
-        "cost_currency": "EUR",
         "fee": 0,
         "fee_currency": "BTC",
         "amount": 82,
         "location": "external",
     }, {
         'timestamp': 1449809536,  # cryptocompare hourly BTC/EUR price: 386.175
-        'pair': 'BTC_XMR',  # cryptocompare hourly XMR/EUR price: 0.396987900
+        'pair': 'XMR_BTC',  # cryptocompare hourly XMR/EUR price: 0.396987900
         'type': 'buy',  # Buy XMR with BTC
         'rate': 0.0010275,
-        'cost': 0.3853125,
-        'cost_currency': 'BTC',
         'fee': 0.9375,
         'fee_currency': 'XMR',
         'amount': 375,
@@ -145,8 +81,6 @@ def test_selling_crypto_bought_with_crypto(accountant):
         'pair': 'XMR_EUR',
         'type': 'sell',  # Sell XMR for EUR
         'rate': 1.0443027675,
-        'cost': 46.9936245375,
-        'cost_currency': 'EUR',
         'fee': 0.117484061344,
         'fee_currency': 'EUR',
         'amount': 45,
@@ -174,8 +108,6 @@ def test_buying_selling_eth_before_daofork(accountant):
             "pair": "ETH_EUR",
             "type": "buy",
             "rate": 0.2315893,
-            "cost": 335.804485,
-            "cost_currency": "EUR",
             "fee": 0,
             "fee_currency": "ETH",
             "amount": 1450,
@@ -185,8 +117,6 @@ def test_buying_selling_eth_before_daofork(accountant):
             'pair': 'ETH_EUR',  # cryptocompare hourly ETC/EUR price: 7.88
             'type': 'sell',
             'rate': 7.88,
-            'cost': 394,
-            'cost_currency': 'EUR',
             'fee': 0.5215,
             'fee_currency': 'EUR',
             'amount': 50,
@@ -196,8 +126,6 @@ def test_buying_selling_eth_before_daofork(accountant):
             'pair': 'ETC_EUR',  # cryptocompare hourly ETC/EUR price: 1.78
             'type': 'sell',  # not-taxable -- considered bought with ETH so after year
             'rate': 1.78,
-            'cost': 979,
-            'cost_currency': 'EUR',
             'fee': 0.9375,
             'fee_currency': 'EUR',
             'amount': 550,
@@ -207,8 +135,6 @@ def test_buying_selling_eth_before_daofork(accountant):
             'pair': 'ETH_EUR',  # cryptocompare hourly ETC/EUR price: 7.45
             'type': 'sell',  # not taxable after 1 year
             'rate': 7.45,
-            'cost': 74.5,
-            'cost_currency': 'EUR',
             'fee': 0.12,
             'fee_currency': 'EUR',
             'amount': 10,
@@ -230,8 +156,6 @@ def test_buying_selling_btc_before_bchfork(accountant):
         "pair": "BTC_EUR",
         "type": "buy",
         "rate": 1128.905,
-        "cost": 7337.8825,
-        "cost_currency": "EUR",
         "fee": 0.55,
         "fee_currency": "EUR",
         "amount": 6.5,
@@ -241,8 +165,6 @@ def test_buying_selling_btc_before_bchfork(accountant):
         "pair": "BTC_EUR",
         "type": "sell",
         "rate": 2380.835,
-        "cost": 1190.4175,
-        "cost_currency": "EUR",
         "fee": 0.15,
         "fee_currency": "EUR",
         "amount": 0.5,
@@ -252,8 +174,6 @@ def test_buying_selling_btc_before_bchfork(accountant):
         'pair': 'BCH_EUR',  # cryptocompare hourly BCH/EUR price: 995.935
         'type': 'sell',
         'rate': 995.935,
-        'cost': 2091.4635,
-        'cost_currency': 'EUR',
         'fee': 0.26,
         'fee_currency': 'EUR',
         'amount': 2.1,
@@ -263,8 +183,6 @@ def test_buying_selling_btc_before_bchfork(accountant):
         'pair': 'BTC_EUR',  # cryptocompare hourly BCH/EUR price: 995.935
         'type': 'sell',
         'rate': 12404.88,
-        'cost': 14885.856,
-        'cost_currency': 'EUR',
         'fee': 0.52,
         'fee_currency': 'EUR',
         'amount': 1.2,
@@ -292,8 +210,6 @@ history5 = history1 + [{
     "pair": "BTC_EUR",  # cryptocompare hourly ETH/EUR price: 11.925
     "type": "sell",
     "rate": 13503.35,
-    "cost": 270067,
-    "cost_currency": "EUR",
     "fee": 0,
     "fee_currency": "BTC",
     "amount": 20.0,
@@ -332,8 +248,6 @@ def test_buy_event_creation(accountant):
         "pair": "BTC_EUR",
         "type": "buy",
         "rate": 578.505,
-        "cost": 2892.525,
-        "cost_currency": "EUR",
         "fee": 0.0012,
         "fee_currency": "BTC",
         "amount": 5,
@@ -343,8 +257,6 @@ def test_buy_event_creation(accountant):
         "pair": "BTC_EUR",
         "type": "buy",
         "rate": 578.505,
-        "cost": 2892.525,
-        "cost_currency": "EUR",
         "fee": 0.0012,
         "fee_currency": "EUR",
         "amount": 5,
@@ -372,8 +284,6 @@ def test_not_include_gas_costs(accountant):
         "pair": "BTC_EUR",
         "type": "buy",
         "rate": 578.505,
-        "cost": 2892.525,
-        "cost_currency": "EUR",
         "fee": 0.0012,
         "fee_currency": "BTC",
         "amount": 5,
@@ -383,8 +293,6 @@ def test_not_include_gas_costs(accountant):
         "pair": "BTC_EUR",
         "type": "sell",
         "rate": 2519.62,
-        "cost": 2519.62,
-        "cost_currency": "EUR",
         "fee": 0.02,
         "fee_currency": "EUR",
         "amount": 1,
@@ -419,8 +327,6 @@ def test_ignored_assets(accountant):
         "pair": "DASH_EUR",
         "type": "buy",
         "rate": 9.76775956284,
-        "cost": 97.6775956284,
-        "cost_currency": "EUR",
         "fee": 0.0011,
         "fee_currency": "DASH",
         "amount": 10,
@@ -430,8 +336,6 @@ def test_ignored_assets(accountant):
         "pair": "DASH_EUR",
         "type": "sell",
         "rate": 128.09,
-        "cost": 640.45,
-        "cost_currency": "EUR",
         "fee": 0.015,
         "fee_currency": "EUR",
         "amount": 5,
@@ -448,19 +352,15 @@ def test_settlement_buy(accountant):
         "pair": "BTC_EUR",
         "type": "buy",
         "rate": 578.505,
-        "cost": 2892.525,
-        "cost_currency": "EUR",
         "fee": 0.0012,
         "fee_currency": "BTC",
         "amount": 5,
         "location": "kraken",
     }, {  # 0.0079275 * 810.49 + 0.15 * 12.4625608386372145 = 8.29454360079
         'timestamp': 1484629704,  # 17/01/2017
-        'pair': 'BTC_DASH',  # DASH/EUR price: 12.4625608386372145
+        'pair': 'DASH_BTC',  # DASH/EUR price: 12.4625608386372145
         'type': 'settlement_buy',  # Buy DASH with BTC to settle. Essentially BTC loss
         'rate': 0.015855,  # BTC/EUR price: 810.49
-        'cost': 0.0079275,
-        'cost_currency': 'BTC',
         'fee': 0.15,
         'fee_currency': 'DASH',
         'amount': 0.5,
@@ -470,8 +370,6 @@ def test_settlement_buy(accountant):
         "pair": "BTC_EUR",
         "type": "sell",
         "rate": 2519.62,
-        "cost": 2519.62,
-        "cost_currency": "EUR",
         "fee": 0.02,
         "fee_currency": "EUR",
         "amount": 1,
@@ -496,8 +394,6 @@ def test_margin_events_affect_gained_lost_amount(accountant):
         "pair": "BTC_EUR",
         "type": "buy",
         "rate": 578.505,
-        "cost": 2892.525,
-        "cost_currency": "EUR",
         "fee": 0.0012,
         "fee_currency": "BTC",
         "amount": 5,
@@ -507,8 +403,6 @@ def test_margin_events_affect_gained_lost_amount(accountant):
         "pair": "BTC_EUR",
         "type": "sell",
         "rate": 2519.62,
-        "cost": 2519.62,
-        "cost_currency": "EUR",
         "fee": 0.02,
         "fee_currency": "EUR",
         "amount": 1,
@@ -550,8 +444,6 @@ def test_no_corresponding_buy_for_sell(accountant):
         "pair": "BTC_EUR",
         "type": "sell",
         "rate": 2519.62,
-        "cost": 2519.62,
-        "cost_currency": "EUR",
         "fee": 0.02,
         "fee_currency": "EUR",
         "amount": 1,

--- a/rotkehlchen/tests/test_binance.py
+++ b/rotkehlchen/tests/test_binance.py
@@ -8,8 +8,8 @@ import pytest
 from rotkehlchen.binance import Binance, trade_from_binance
 from rotkehlchen.errors import RemoteError
 from rotkehlchen.fval import FVal
-from rotkehlchen.order_formatting import Trade
 from rotkehlchen.tests.utils.mock import MockResponse
+from rotkehlchen.typing import Trade
 
 
 @pytest.fixture
@@ -79,52 +79,44 @@ def test_trade_from_binance(mock_binance):
     ]
     our_expected_list = [
         Trade(
-            timestamp=1512561941,
+            time=1512561941,
+            location='binance',
             pair='RDN_ETH',
-            type='buy',
+            trade_type='buy',
+            amount=FVal(5.0),
             rate=FVal(0.0063213),
-            cost=FVal(0.03160650),
-            cost_currency='ETH',
             fee=FVal(0.005),
             fee_currency='RDN',
-            amount=FVal(5.0),
-            location='binance',
         ),
         Trade(
-            timestamp=1531117990,
+            time=1531117990,
+            location='binance',
             pair='ETH_USDT',
-            type='sell',
+            trade_type='sell',
+            amount=FVal(0.505),
             rate=FVal(481.0),
-            cost=FVal(242.905),
-            cost_currency='USDT',
             fee=FVal(0.242905),
             fee_currency='USDT',
-            amount=FVal(0.505),
-            location='binance',
         ),
         Trade(
-            timestamp=1531728338,
+            time=1531728338,
+            location='binance',
             pair='BTC_USDT',
-            type='buy',
+            trade_type='buy',
+            amount=FVal(0.051942),
             rate=FVal(6376.39),
-            cost=FVal(331.20244938),
-            cost_currency='USDT',
             fee=FVal(0.00005194),
             fee_currency='BTC',
-            amount=FVal(0.051942),
-            location='binance',
         ),
         Trade(
-            timestamp=1531871806,
+            time=1531871806,
+            location='binance',
             pair='ADA_USDT',
-            type='sell',
+            trade_type='sell',
+            amount=FVal(285.2),
             rate=FVal(0.17442),
-            cost=FVal(49.744584),
-            cost_currency='USDT',
             fee=FVal(0.00180015),
             fee_currency='BNB',
-            amount=FVal(285.2),
-            location='binance',
         ),
     ]
 

--- a/rotkehlchen/tests/test_binance.py
+++ b/rotkehlchen/tests/test_binance.py
@@ -8,8 +8,8 @@ import pytest
 from rotkehlchen.binance import Binance, trade_from_binance
 from rotkehlchen.errors import RemoteError
 from rotkehlchen.fval import FVal
+from rotkehlchen.order_formatting import Trade
 from rotkehlchen.tests.utils.mock import MockResponse
-from rotkehlchen.typing import Trade
 
 
 @pytest.fixture
@@ -79,7 +79,7 @@ def test_trade_from_binance(mock_binance):
     ]
     our_expected_list = [
         Trade(
-            time=1512561941,
+            timestamp=1512561941,
             location='binance',
             pair='RDN_ETH',
             trade_type='buy',
@@ -89,7 +89,7 @@ def test_trade_from_binance(mock_binance):
             fee_currency='RDN',
         ),
         Trade(
-            time=1531117990,
+            timestamp=1531117990,
             location='binance',
             pair='ETH_USDT',
             trade_type='sell',
@@ -99,7 +99,7 @@ def test_trade_from_binance(mock_binance):
             fee_currency='USDT',
         ),
         Trade(
-            time=1531728338,
+            timestamp=1531728338,
             location='binance',
             pair='BTC_USDT',
             trade_type='buy',
@@ -109,7 +109,7 @@ def test_trade_from_binance(mock_binance):
             fee_currency='BTC',
         ),
         Trade(
-            time=1531871806,
+            timestamp=1531871806,
             location='binance',
             pair='ADA_USDT',
             trade_type='sell',

--- a/rotkehlchen/tests/test_end_to_end_tax_report.py
+++ b/rotkehlchen/tests/test_end_to_end_tax_report.py
@@ -16,8 +16,6 @@ trades_history = [
         'pair': 'BTC_EUR',
         'type': 'buy',
         'rate': 268.678317859,
-        'cost': 1343.3915893,
-        'cost_currency': 'EUR',
         'fee': 0,
         'fee_currency': 'BTC',
         'amount': 5,
@@ -27,8 +25,6 @@ trades_history = [
         'pair': 'ETH_EUR',
         'type': 'buy',
         'rate': 0.2315893,
-        'cost': 335.804485,
-        'cost_currency': 'EUR',
         'fee': 0,
         'fee_currency': 'ETH',
         'amount': 1450,
@@ -38,41 +34,33 @@ trades_history = [
         'pair': 'BTC_EUR',  # cryptocompare hourly BTC/EUR price 612.45
         'type': 'sell',
         'rate': 612.45,
-        'cost': 1531.125,
-        'cost_currency': 'EUR',
         'fee': '0.15',
         'fee_currency': 'EUR',
         'amount': 2.5,
         'location': 'kraken',
     }, {
         'timestamp': 1473505138,  # 10/09/2016
-        'pair': 'BTC_ETH',  # cryptocompare hourly ETH/EUR price: 10.365
+        'pair': 'ETH_BTC',  # cryptocompare hourly ETH/EUR price: 10.365
         'type': 'buy',  # Buy ETH with BTC -- taxable (within 1 year)
         'rate': 0.01858275,  # cryptocompare hourly BTC/EUR price: 556.435
-        'cost': 0.9291375,
-        'cost_currency': 'BTC',
         'fee': 0.06999999999999999,
         'fee_currency': 'ETH',
         'amount': 50.0,
         'location': 'poloniex',
     }, {
         'timestamp': 1475042230,  # 28/09/2016
-        'pair': 'BTC_ETH',  # cryptocompare hourly ETH/EUR price: 11.925
+        'pair': 'ETH_BTC',  # cryptocompare hourly ETH/EUR price: 11.925
         'type': 'sell',  # Sell ETH for BTC -- taxable (within 1 year)
         'rate': 0.022165,  # cryptocompare hourly BTC/EUR price: 537.805
-        'cost': 0.554125,
-        'cost_currency': 'BTC',  # reminder: we calculate buying cost with paid
         'fee': 0.001,            # asset. In this case 'ETH'. So BTC buy rate is:
         'fee_currency': 'ETH',   # (1 / 0.022165) * 11.925
         'amount': 25,
         'location': 'poloniex',
     }, {
         'timestamp': 1476536704,  # 15/10/2016
-        'pair': 'BTC_ETH',  # cryptocompare hourly ETH/EUR price: 10.775
+        'pair': 'ETH_BTC',  # cryptocompare hourly ETH/EUR price: 10.775
         'type': 'sell',  # Sell ETH for BTC -- taxable (within 1 year)
         'rate': 0.018355,  # cryptocompare hourly BTC/EUR price: 585.96
-        'cost': 3.3039,
-        'cost_currency': 'BTC',  # reminder: we calculate buying cost with paid
         'fee': 0.01,             # asset.In this case 'ETH'. So BTC buy rate is:
         'fee_currency': 'ETH',   # (1 / 0.018355) * 10.775
         'amount': 180.0,
@@ -82,8 +70,6 @@ trades_history = [
         'pair': 'DASH_BTC',  # cryptocompare hourly DASH/EUR price: 8.9456
         'type': 'buy',  # Buy DASH with BTC -- non taxable (after 1 year)
         'rate': 0.0134,  # cryptocompare hourly BTC/EUR price: 667.185
-        'cost': 0.536,
-        'cost_currency': 'BTC',
         'fee': 0.00082871175,
         'fee_currency': 'BTC',
         'amount': 40,
@@ -93,8 +79,6 @@ trades_history = [
         'pair': 'DASH_BTC',  # cryptocompare hourly DASH/EUR price: 8.104679571509114828039
         'type': 'settlement_sell',  # settlement sell DASH for BTC -- taxable (within 1 year)
         'rate': 0.011265,  # cryptocompare hourly BTC/EUR price: 723.505
-        'cost': 0.00146445,
-        'cost_currency': 'BTC',
         'fee': 0.005,
         'fee_currency': 'DASH',
         'amount': 0.13,
@@ -104,19 +88,15 @@ trades_history = [
         'pair': 'DASH_EUR',  # cryptocompare hourly DASH/EUR price: 12.92517
         'type': 'sell',  # Sell DASH for EUR -- taxable (within 1 year)
         'rate': 12.92517,
-        'cost': 129.2517,
-        'cost_currency': 'EUR',
         'fee': 0.01,
         'fee_currency': 'EUR',
         'amount': 10,
         'location': 'kraken',
     }, {  # 0.0079275 * 810.49 + 0.15 * 12.4625608386372145 = 8.29454360079
         'timestamp': 1484629704,  # 17/01/2017
-        'pair': 'BTC_DASH',  # DASH/EUR price: 12.4625608386372145
+        'pair': 'DASH_BTC',  # DASH/EUR price: 12.4625608386372145
         'type': 'settlement_buy',  # Buy DASH with BTC to settle. Essentially BTC loss
         'rate': 0.015855,  # BTC/EUR price: 810.49
-        'cost': 0.0079275,
-        'cost_currency': 'BTC',
         'fee': 0.15,
         'fee_currency': 'DASH',
         'amount': 0.5,
@@ -126,8 +106,6 @@ trades_history = [
         'pair': 'DASH_BTC',  # cryptocompare hourly DASH/EUR price: 15.36169816590634019
         'type': 'settlement_sell',  # settlement sell DASH for BTC -- taxable (within 1 year)
         'rate': 0.016315,  # cryptocompare hourly BTC/EUR price: 942.78
-        'cost': 0.00244725,
-        'cost_currency': 'BTC',
         'fee': 0.01,
         'fee_currency': 'DASH',
         'amount': 0.15,
@@ -137,8 +115,6 @@ trades_history = [
         'pair': 'BTC_EUR',  # cryptocompare hourly DASH/EUR price: 15.36169816590634019
         'type': 'sell',  # sell BTC for EUR -- partly taxable (within 1 year)
         'rate': 1146.22,  # cryptocompare hourly BTC/EUR price: 1146.22
-        'cost': 2292.44,
-        'cost_currency': 'EUR',
         'fee': 0.01,
         'fee_currency': 'EUR',
         'amount': 2,

--- a/rotkehlchen/tests/test_inquirer.py
+++ b/rotkehlchen/tests/test_inquirer.py
@@ -5,6 +5,7 @@ import pytest
 import requests
 
 from rotkehlchen.fval import FVal
+from rotkehlchen.inquirer import _query_currency_converterapi, _query_exchanges_rateapi
 from rotkehlchen.tests.utils.mock import MockResponse
 from rotkehlchen.utils import ts_now, tsToDate
 
@@ -14,10 +15,10 @@ from rotkehlchen.utils import ts_now, tsToDate
     reason='some of these APIs frequently become unavailable',
 )
 @pytest.mark.parametrize('use_clean_caching_directory', [True])
-def test_query_realtime_price_apis(inquirer):
-    result = inquirer._query_currency_converterapi('USD', 'EUR')
+def test_query_realtieme_price_apis(inquirer):
+    result = _query_currency_converterapi('USD', 'EUR')
     assert result and isinstance(result, FVal)
-    result = inquirer._query_exchanges_rateapi('USD', 'GBP')
+    result = _query_exchanges_rateapi('USD', 'GBP')
     assert result and isinstance(result, FVal)
     result = inquirer.query_historical_fiat_exchange_rates('USD', 'CNY', 1411603200)
     assert result == FVal('6.1371932033')

--- a/rotkehlchen/tests/test_kraken.py
+++ b/rotkehlchen/tests/test_kraken.py
@@ -6,7 +6,7 @@ from rotkehlchen.kraken import (
     kraken_to_world_pair,
     trade_from_kraken,
 )
-from rotkehlchen.typing import Trade
+from rotkehlchen.order_formatting import Trade
 from rotkehlchen.utils import ts_now
 
 

--- a/rotkehlchen/tests/test_kraken.py
+++ b/rotkehlchen/tests/test_kraken.py
@@ -6,7 +6,7 @@ from rotkehlchen.kraken import (
     kraken_to_world_pair,
     trade_from_kraken,
 )
-from rotkehlchen.order_formatting import Trade
+from rotkehlchen.typing import Trade
 from rotkehlchen.utils import ts_now
 
 

--- a/rotkehlchen/tests/test_poloniex.py
+++ b/rotkehlchen/tests/test_poloniex.py
@@ -2,8 +2,8 @@ import os
 from unittest.mock import patch
 
 from rotkehlchen.fval import FVal
-from rotkehlchen.order_formatting import Trade
 from rotkehlchen.poloniex import Poloniex, trade_from_poloniex
+from rotkehlchen.typing import Trade
 
 
 def test_trade_from_poloniex():
@@ -28,11 +28,10 @@ def test_trade_from_poloniex():
 
     assert isinstance(trade, Trade)
     assert isinstance(trade.timestamp, int)
-    assert trade.timestamp == 1500758317
-    assert trade.type == 'sell'
+    assert trade.time == 1500758317
+    assert trade.trade_type == 'sell'
     assert trade.rate == rate
     assert trade.amount == amount
-    assert trade.cost == cost
     assert trade.cost_currency == 'BTC'
     assert trade.fee == cost * perc_fee
     assert trade.fee_currency == 'BTC'

--- a/rotkehlchen/tests/test_poloniex.py
+++ b/rotkehlchen/tests/test_poloniex.py
@@ -2,8 +2,8 @@ import os
 from unittest.mock import patch
 
 from rotkehlchen.fval import FVal
+from rotkehlchen.order_formatting import Trade
 from rotkehlchen.poloniex import Poloniex, trade_from_poloniex
-from rotkehlchen.typing import Trade
 
 
 def test_trade_from_poloniex():
@@ -28,11 +28,11 @@ def test_trade_from_poloniex():
 
     assert isinstance(trade, Trade)
     assert isinstance(trade.timestamp, int)
-    assert trade.time == 1500758317
+    assert trade.timestamp == 1500758317
     assert trade.trade_type == 'sell'
     assert trade.rate == rate
     assert trade.amount == amount
-    assert trade.cost_currency == 'BTC'
+    assert trade.pair == 'ETH_BTC'
     assert trade.fee == cost * perc_fee
     assert trade.fee_currency == 'BTC'
     assert trade.location == 'poloniex'

--- a/rotkehlchen/tests/test_utils.py
+++ b/rotkehlchen/tests/test_utils.py
@@ -3,6 +3,7 @@ import json
 import pytest
 
 from rotkehlchen.fval import FVal
+from rotkehlchen.order_formatting import invert_pair
 from rotkehlchen.server import process_result
 from rotkehlchen.utils import iso8601ts_to_timestamp
 
@@ -40,3 +41,10 @@ def test_iso8601ts_to_timestamp():
     assert iso8601ts_to_timestamp('2018-09-09T12:00:00.000Z') == 1536494400
     assert iso8601ts_to_timestamp('2011-01-01T04:13:22.220Z') == 1293855202
     assert iso8601ts_to_timestamp('1986-11-04T16:23:57.921Z') == 531505437
+
+
+def test_invert_pair():
+    assert invert_pair('BTC_ETH') == 'ETH_BTC'
+    assert invert_pair('XMR_EUR') == 'EUR_XMR'
+    with pytest.raises(ValueError):
+        assert invert_pair('sdsadasd')

--- a/rotkehlchen/typing.py
+++ b/rotkehlchen/typing.py
@@ -64,22 +64,6 @@ T_EventType = str
 EventType = NewType('EventType', T_EventType)
 
 
-class Trade(NamedTuple):
-    """Represents a Trade"""
-    timestamp: Timestamp
-    location: str
-    pair: str
-    trade_type: str
-    # The amount represents the amount bought if it's a buy or or the amount
-    # sold if it's a sell
-    amount: FVal
-    rate: FVal
-    fee: FVal
-    fee_currency: Asset
-    link: str = ''
-    notes: str = ''
-
-
 class EthereumTransaction(NamedTuple):
     """Represent an Ethereum transaction"""
     timestamp: Timestamp

--- a/rotkehlchen/typing.py
+++ b/rotkehlchen/typing.py
@@ -66,7 +66,7 @@ EventType = NewType('EventType', T_EventType)
 
 class Trade(NamedTuple):
     """Represents a Trade"""
-    time: Timestamp
+    timestamp: Timestamp
     location: str
     pair: str
     trade_type: str
@@ -76,8 +76,8 @@ class Trade(NamedTuple):
     rate: FVal
     fee: FVal
     fee_currency: Asset
-    link: str
-    notes: str
+    link: str = ''
+    notes: str = ''
 
 
 class EthereumTransaction(NamedTuple):

--- a/tools/data_faker/data_faker/actions.py
+++ b/tools/data_faker/data_faker/actions.py
@@ -158,7 +158,7 @@ class ActionWriter(object):
 
         # create the trade
         trade = Trade(
-            time=ts,
+            timestamp=ts,
             location='kraken',
             pair=pair,
             trade_type=action_type,

--- a/tools/data_faker/data_faker/actions.py
+++ b/tools/data_faker/data_faker/actions.py
@@ -3,8 +3,8 @@ import random
 
 from rotkehlchen.constants import FIAT_CURRENCIES
 from rotkehlchen.fval import FVal
-from rotkehlchen.order_formatting import pair_get_assets
-from rotkehlchen.typing import Asset, Timestamp, Trade
+from rotkehlchen.order_formatting import Trade, pair_get_assets
+from rotkehlchen.typing import Asset, Timestamp
 
 STARTING_TIMESTAMP = 1464739200  # 01/06/2016
 NUMBER_OF_TRADES = 5

--- a/tools/data_faker/data_faker/fake_kraken.py
+++ b/tools/data_faker/data_faker/fake_kraken.py
@@ -3,8 +3,9 @@ import os
 
 from rotkehlchen.fval import FVal
 from rotkehlchen.kraken import WORLD_TO_KRAKEN
+from rotkehlchen.order_formatting import Trade
 from rotkehlchen.tests.fixtures.exchanges.kraken import create_kraken_trade
-from rotkehlchen.typing import Asset, Timestamp, Trade
+from rotkehlchen.typing import Asset, Timestamp
 from rotkehlchen.utils import process_result
 
 

--- a/tools/data_faker/data_faker/fake_kraken.py
+++ b/tools/data_faker/data_faker/fake_kraken.py
@@ -59,7 +59,7 @@ class FakeKraken(object):
         kraken_trade = create_kraken_trade(
             tradeable_pairs=list(self.asset_pairs['result'].keys()),
             pair=trade.pair,
-            time=trade.time,
+            time=trade.timestamp,
             trade_type=trade.trade_type,
             rate=trade.rate,
             amount=trade.amount,


### PR DESCRIPTION
All rotkehlchen trades now exclusively follow the BASE_QUOTE convention which means that in `BTC_ETH` you will always be buying `BTC` with `ETH` and selling `BTC` for `ETH`.

Now when importing trades from exchanges which don't follow this convention (Poloniex, Bittrex) the pairs are swapped to always comply with the convention when turned into the Rotkehlchen format.

This allows us to remove the `cost` and `cost_currency` attributes of each trade. And also the duplicated `Trade` named tuple.