### PR TITLE
 Swap order of forex exchange queries and add api key for one 

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :bug:`314` Exchangerates api is now queried with priority and as such there are no more delays at the startup of the application due to unresponsive FOREX api calls.
 * :feature:`272` Added a statistics pane. Premium users can now see a graph of their net value over time there.
 * :bug:`299` IOTA historical price queries now work properly.
 * :bug:`288` After a user re-login querying fiat prices will no longer throw exceptions.

--- a/rotkehlchen/constants.py
+++ b/rotkehlchen/constants.py
@@ -48,6 +48,8 @@ EV_LOAN_SETTLE = typing.EventType('loan_settlement')
 EV_INTEREST_PAYMENT = typing.EventType('interest_rate_payment')
 EV_MARGIN_CLOSE = typing.EventType('margin_position_close')
 
+CURRENCYCONVERTER_API_KEY = '7ad371210f296db27c19'
+
 
 ZERO = FVal(0)
 

--- a/rotkehlchen/inquirer.py
+++ b/rotkehlchen/inquirer.py
@@ -8,6 +8,7 @@ from typing import Dict, Iterable, Optional, cast
 import requests
 
 from rotkehlchen.constants import (
+    CURRENCYCONVERTER_API_KEY,
     FIAT_CURRENCIES,
     S_BCHSV,
     S_BQX,
@@ -124,8 +125,11 @@ def _query_currency_converterapi(base: FiatAsset, quote: FiatAsset) -> Optional[
         base_currency=base,
         quote_currency=quote,
     )
-    pair = '{}_{}'.format(base, quote)
-    querystr = 'https://free.currencyconverterapi.com/api/v5/convert?q={}'.format(pair)
+    pair = f'{base}_{quote}'
+    querystr = (
+        f'https://free.currencyconverterapi.com/api/v6/convert?'
+        f'q={pair}&apiKey={CURRENCYCONVERTER_API_KEY}'
+    )
     try:
         resp = request_get_dict(querystr)
         return FVal(resp['results'][pair]['val'])
@@ -291,9 +295,9 @@ class Inquirer(object):
         if price:
             return price
 
-        price = _query_currency_converterapi(base, quote)
+        price = _query_exchanges_rateapi(base, quote)
         if not price:
-            price = _query_exchanges_rateapi(base, quote)
+            price = _query_currency_converterapi(base, quote)
 
         if not price:
             # Search the cache for any price in the last month

--- a/rotkehlchen/tests/test_inquirer.py
+++ b/rotkehlchen/tests/test_inquirer.py
@@ -15,7 +15,7 @@ from rotkehlchen.utils import ts_now, tsToDate
     reason='some of these APIs frequently become unavailable',
 )
 @pytest.mark.parametrize('use_clean_caching_directory', [True])
-def test_query_realtieme_price_apis(inquirer):
+def test_query_realtime_price_apis(inquirer):
     result = _query_currency_converterapi('USD', 'EUR')
     assert result and isinstance(result, FVal)
     result = _query_exchanges_rateapi('USD', 'GBP')
@@ -29,14 +29,14 @@ def test_switching_to_backup_api(inquirer):
     count = 0
     original_get = requests.get
 
-    def mock_currency_converter_fail(uri):
+    def mock_exchanges_rateapi_fail(uri):
         nonlocal count
         count += 1
-        if 'currencyconverterapi' in uri:
+        if 'exchangeratesapi' in uri:
             return MockResponse(501, '{"msg": "some error")')
         return original_get(uri)
 
-    with patch('requests.get', side_effect=mock_currency_converter_fail):
+    with patch('requests.get', side_effect=mock_exchanges_rateapi_fail):
         result = inquirer.query_fiat_pair('USD', 'EUR')
         assert result and isinstance(result, FVal)
         assert count > 1, 'requests.get should have been called more than once'


### PR DESCRIPTION
Fix #314

- We now first query exchangesrateapi since it's the most reliable
  API.
- If for some reason that fails, we now added a throwaway API key to
  the currencyconverter api so it works again and will query it as a
  fallback.

Testing the initialization of rotkehlchen with this change it works
much faster providing the solution to #314, because it no longer makes
5 failed attempts to query currencyconverterapi.