### PR TITLE
Convert XRB to NANO

### DIFF
--- a/rotkehlchen/constants.py
+++ b/rotkehlchen/constants.py
@@ -5,7 +5,6 @@ from rotkehlchen.fval import FVal
 
 ETH_DAO_FORK_TS = 1469020840  # 2016-07-20 13:20:40 UTC
 BTC_BCH_FORK_TS = 1501593374  # 2017-08-01 13:16:14 UTC
-XRB_NANO_REBRAND_TS = 1525132800  # 2018-05-01 2:00 AM UTC
 
 SUPPORTED_EXCHANGES = ['kraken', 'poloniex', 'bittrex', 'bitmex', 'binance']
 ROTKEHLCHEN_SERVER_TIMEOUT = 5

--- a/rotkehlchen/history.py
+++ b/rotkehlchen/history.py
@@ -508,8 +508,8 @@ class PriceHistorian(object):
         if price == 0:
             if from_asset != 'BTC' and to_asset != 'BTC':
                 log.debug(
-                    f"Coudn't find historical price from {from_asset} to "
-                    f"{to_asset}. Comparing with BTC...",
+                    f"Couldn't find historical price from {from_asset} to "
+                    f"{to_asset} at timestamp {timestamp}. Comparing with BTC...",
                 )
                 # Just get the BTC price
                 asset_btc_price = self.query_historical_price(from_asset, 'BTC', timestamp)
@@ -517,8 +517,8 @@ class PriceHistorian(object):
                 price = asset_btc_price * btc_to_asset_price
             else:
                 log.debug(
-                    f"Coudn't find historical price from {from_asset} to "
-                    f"{to_asset}. Attempting to get daily price...",
+                    f"Couldn't find historical price from {from_asset} to "
+                    f"{to_asset} at timestamp {timestamp}. Attempting to get daily price...",
                 )
                 # attempt to get the daily price by timestamp
                 cc_from_asset = world_to_cryptocompare(from_asset, timestamp)

--- a/rotkehlchen/inquirer.py
+++ b/rotkehlchen/inquirer.py
@@ -6,7 +6,6 @@ from json.decoder import JSONDecodeError
 from typing import Dict, Iterable, Optional, cast
 
 import requests
-
 from rotkehlchen.constants import (
     CURRENCYCONVERTER_API_KEY,
     FIAT_CURRENCIES,
@@ -18,7 +17,6 @@ from rotkehlchen.constants import (
     S_RAIBLOCKS,
     S_RDN,
     S_USD,
-    XRB_NANO_REBRAND_TS,
 )
 from rotkehlchen.errors import RemoteError
 from rotkehlchen.fval import FVal
@@ -57,9 +55,7 @@ def world_to_cryptocompare(asset: Asset, timestamp: Timestamp = None) -> Asset:
         asset = cast(NonEthTokenBlockchainAsset, 'BSV')
     elif asset == S_BQX:
         asset = cast(EthToken, 'ETHOS')
-    elif asset == S_NANO and timestamp and timestamp < XRB_NANO_REBRAND_TS:
-        return S_RAIBLOCKS
-    elif asset == S_RAIBLOCKS and timestamp and timestamp >= XRB_NANO_REBRAND_TS:
+    elif asset == S_RAIBLOCKS:
         return S_NANO
 
     return asset


### PR DESCRIPTION
It seems like right after we fixed #273, CryptoCompare started returning prices only for NANO symbol even before the given timestamp. After debugging the issue by calling the CC API with:

https://min-api.cryptocompare.com/data/pricehistorical?fsym=NANO&tsyms=EUR&ts=1519637869

where `1519637869` is before the rebrand timestamp, the call returns a valid price while converting `fsym` to `XRB` would return 0.

Also, fixed a typo and added timestamp at which the failure to fetch price happens.