### PR TITLE
Bump webargs to 5.1.3 because of CVE-2019-9710

### DIFF
--- a/tools/data_faker/requirements.txt
+++ b/tools/data_faker/requirements.txt
@@ -1,5 +1,5 @@
 # rotkehlchen
-webargs==2.0.0
+webargs==5.1.3
 Flask-Restful==0.3.7
 Flask==1.0.2
 marshmallow==2.17.0


### PR DESCRIPTION
https://nvd.nist.gov/vuln/detail/CVE-2019-9710#vulnCurrentDescriptionTitle