### PR TITLE
Temporarily skip cryptocompare price history sanity tests

### DIFF
--- a/rotkehlchen/tests/test_price_history.py
+++ b/rotkehlchen/tests/test_price_history.py
@@ -8,6 +8,7 @@ from rotkehlchen.tests.utils.constants import A_BSV, A_DASH, A_IOTA
 from rotkehlchen.tests.utils.history import prices
 
 
+@pytest.mark.skip("https://github.com/rotkehlchenio/rotkehlchen/issues/377")
 @pytest.mark.parametrize('should_mock_price_queries', [False])
 def test_incosistent_prices_double_checking(price_historian):
     """ This is a regression test for the incosistent DASH/EUR and DASH/USD prices
@@ -48,6 +49,7 @@ def do_queries_for(from_asset, to_asset, price_historian):
         assert price.is_close(pair_map[timestamp]), msg
 
 
+@pytest.mark.skip("https://github.com/rotkehlchenio/rotkehlchen/issues/377")
 @pytest.mark.parametrize('should_mock_price_queries', [False])
 def test_price_queries(price_historian):
     """Test some cryptocompare price queries making sure our querying mechanism works"""


### PR DESCRIPTION
Related to #377 

Cryptocompare is changing the way historical data are returned.

Quoting @vcealicu:

We decide on historical trading path based on the current trading volume

If MLN trades a lot of ETH on one day, and you ask for historical MLN-USD, we do it as MLN-ETH × ETH-USD

If next day, it trades more in BTC

We historical as MLN-BTC × BTC-USD.

----

So for this week while this transition is happening results may vary
so the tests should be temporarily skipped until the transition is complete.