### PR TITLE
Tracking accounts/tokens changes in user settings should reflect on the dashboard

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :bug:`325` Tracking accounts/tokens in user settings will now be immediately reflected on the dashboard.
 * :bug:`368` Fixes broken navigation after visiting Statistics page.
 * :bug:`361` Rotkehlchen no longer misses the last trade when processing history inside a timerange.
 * :bug:`349` Copy paste should now work on OSX.

--- a/ui/balances_table.ts
+++ b/ui/balances_table.ts
@@ -149,17 +149,11 @@ export function total_table_modify_balance_for_asset(location: string, asset: st
     total_table_recreate();
 }
 
-export function total_table_modify_balance_for_assets(location: string, data: { [asset: string]: AssetBalance }) {
+export function total_table_modify_all_balances_for_location(location: string, data: { [asset: string]: AssetBalance }) {
     if (!SAVED_BALANCES.hasOwnProperty(location)) {
         SAVED_BALANCES[location] = {};
     }
-    for (const asset in data) {
-        if (!data.hasOwnProperty(asset)) {
-            continue;
-        }
-        SAVED_BALANCES[location][asset] = data[asset];
-    }
-
+    SAVED_BALANCES[location] = data;
     total_table_recreate();
 }
 

--- a/ui/balances_table.ts
+++ b/ui/balances_table.ts
@@ -43,8 +43,15 @@ function create_full_data(): AssetBalance[] {
         if (!inter_data.hasOwnProperty(asset)) {
             continue;
         }
-        total_usd += inter_data[asset]['usd_value'] as number;
+        let asset_usd_value;
+        if (typeof inter_data[asset].usd_value === 'string') {
+            asset_usd_value = parseFloat(inter_data[asset].usd_value as string);
+        } else {
+            asset_usd_value = inter_data[asset].usd_value as number;
+        }
+        total_usd += asset_usd_value;
     }
+
 
     const full_data: AssetBalance[] = [];
     // we should have all balances by now
@@ -52,9 +59,20 @@ function create_full_data(): AssetBalance[] {
         if (!inter_data.hasOwnProperty(asset)) {
             continue;
         }
-        const amount = inter_data[asset].amount as number;
+        let amount;
+        if (typeof inter_data[asset].amount  === 'string') {
+            amount = parseFloat(inter_data[asset].amount as string);
+        } else {
+            amount = inter_data[asset].amount as number;
+        }
+
         const amountStr = amount.toFixed(settings.floating_precision);
-        const value = inter_data[asset].usd_value as number;
+        let value;
+        if (typeof inter_data[asset].usd_value === 'string') {
+            value = parseFloat(inter_data[asset].usd_value as string);
+        } else {
+            value = inter_data[asset].usd_value as number;
+        }
         const percentage = value / total_usd;
         const percentageStr = (percentage * 100).toFixed(settings.floating_precision);
         const valueStr = value.toFixed(settings.floating_precision);
@@ -120,6 +138,28 @@ export function total_table_add_balances(location: string, query_result: { [asse
         data[asset] = {amount: amount, usd_value: value};
     }
     SAVED_BALANCES[location] = data;
+    total_table_recreate();
+}
+
+export function total_table_modify_balance_for_asset(location: string, asset: string, data: AssetBalance) {
+    if (!SAVED_BALANCES.hasOwnProperty(location)) {
+        SAVED_BALANCES[location] = {};
+    }
+    SAVED_BALANCES[location][asset] = data;
+    total_table_recreate();
+}
+
+export function total_table_modify_balance_for_assets(location: string, data: { [asset: string]: AssetBalance }) {
+    if (!SAVED_BALANCES.hasOwnProperty(location)) {
+        SAVED_BALANCES[location] = {};
+    }
+    for (const asset in data) {
+        if (!data.hasOwnProperty(asset)) {
+            continue;
+        }
+        SAVED_BALANCES[location][asset] = data[asset];
+    }
+
     total_table_recreate();
 }
 

--- a/ui/user_settings.ts
+++ b/ui/user_settings.ts
@@ -1,5 +1,5 @@
 import {AssetTable} from './asset_table';
-import {total_table_modify_balance_for_asset, total_table_modify_balance_for_assets} from './balances_table';
+import {total_table_modify_balance_for_asset, total_table_modify_all_balances_for_location} from './balances_table';
 import {create_task, monitor_add_callback} from './monitor';
 import {
     dt_edit_drawcallback,
@@ -388,7 +388,7 @@ function add_blockchain_account(event: JQuery.Event) {
             // update the table with the data
             recreate_ethchain_per_account_table(BB_ETH_ACCOUNT_DATA);
             // also update the data of the dashboard's totals table
-            total_table_modify_balance_for_assets('blockchain', result.totals);
+            total_table_modify_all_balances_for_location('blockchain', result.totals);
         } else if (blockchain === 'BTC') {
             const btcTable = BB_PER_ACCOUNT_TABLES['BTC'] as AssetTable;
             // save the data from the call
@@ -528,6 +528,8 @@ function delete_blockchain_account_row(blockchain: string, row: DataTables.RowMe
         BB_PER_ASSET_DATA = value.totals;
         // and update the table with it
         BB_PER_ASSET_TABLE.update_format(BB_PER_ASSET_DATA);
+        // and finally also update the dashboard table
+        total_table_modify_all_balances_for_location('blockchain', value.totals);
         stop_show_loading();
     }).catch((reason: Error) => {
         showError('Account Deletion Error', `Error at deleting ${blockchain} account ${account}: ${reason.message}`);

--- a/ui/user_settings.ts
+++ b/ui/user_settings.ts
@@ -1,4 +1,5 @@
 import {AssetTable} from './asset_table';
+import {total_table_modify_balance_for_asset, total_table_modify_balance_for_assets} from './balances_table';
 import {create_task, monitor_add_callback} from './monitor';
 import {
     dt_edit_drawcallback,
@@ -386,6 +387,8 @@ function add_blockchain_account(event: JQuery.Event) {
             BB_ETH_ACCOUNT_DATA = result.per_account['ETH'];
             // update the table with the data
             recreate_ethchain_per_account_table(BB_ETH_ACCOUNT_DATA);
+            // also update the data of the dashboard's totals table
+            total_table_modify_balance_for_assets('blockchain', result.totals);
         } else if (blockchain === 'BTC') {
             const btcTable = BB_PER_ACCOUNT_TABLES['BTC'] as AssetTable;
             // save the data from the call
@@ -396,6 +399,8 @@ function add_blockchain_account(event: JQuery.Event) {
             } else {
                 btcTable.update_format(BB_BTC_ACCOUNT_DATA);
             }
+            // also update the data of the dashboard's totals table
+            total_table_modify_balance_for_asset('blockchain', 'BTC', result.totals['BTC']);
         }
         if (BB_PER_ASSET_TABLE == null) {
             throw new Error('Table was not supposed to be null');

--- a/ui/user_settings.ts
+++ b/ui/user_settings.ts
@@ -686,6 +686,8 @@ function add_new_eth_tokens(tokens: string[]) {
         BB_PER_ASSET_DATA = result['totals'];
         // and updating the table with it
         BB_PER_ASSET_TABLE.update_format(BB_PER_ASSET_DATA);
+        // finally also update the dashboard table
+        total_table_modify_all_balances_for_location('blockchain', result.totals);
         enable_multiselect();
         stop_show_loading('#eth_tokens_select');
     }).catch(reason => {
@@ -715,6 +717,8 @@ function remove_eth_tokens(tokens: string[]) {
         BB_PER_ASSET_DATA = result.totals;
         // and updating the table with it
         BB_PER_ASSET_TABLE.update_format(BB_PER_ASSET_DATA);
+        // finally also update the dashboard table
+        total_table_modify_all_balances_for_location('blockchain', result.totals);
         enable_multiselect();
         stop_show_loading('#eth_tokens_select');
     }).catch(reason => {


### PR DESCRIPTION
- Adding a BTC/ETH account should have balances reflected in dashboard
- Removing a BTC/ETH account should have balances reflected in dashboard
- Tracking a new token should have balances reflected in dashboard
- Stoping to track a new token should have balances reflected in dashboard

@kelsos could you have a look? Also ... would it be too much to ask for writting tests for these? Or you think they will need to be deleted once the vue rewrite happens?

Fix #325 