### PR TITLE
 Revising usersettings properly updates per account tables

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :bug:`392` Revising usersettings properly updates per account tables if an account has been deleted before.
 * :bug:`325` Tracking accounts/tokens in user settings will now be immediately reflected on the dashboard.
 * :bug:`368` Fixes broken navigation after visiting Statistics page.
 * :bug:`361` Rotkehlchen no longer misses the last trade when processing history inside a timerange.


### PR DESCRIPTION
Fix #392

If you visit the usersettings and remove an account from either the
ETH or the BTC accounts table it's now also deleted from the saved
data.

This way when you revisit the usersettings after deletion the tables
are properly updated.