### PR TITLE
Upgrade lodash dev dependency for CVE-2019-10744

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2113,9 +2113,9 @@
             }
         },
         "lodash": {
-            "version": "4.17.11",
-            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-            "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
+            "version": "4.17.14",
+            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.14.tgz",
+            "integrity": "sha512-mmKYbW3GLuJeX+iGP+Y7Gp1AiGHGbXHCOh/jZmrawMmsE7MS4znI3RL2FsjbqOyMayHInjOeykW7PEajUk1/xw==",
             "dev": true
         },
         "lodash.assign": {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
         "tslint": "5.11.0",
         "tslint-eslint-rules": "5.4.0",
         "typescript": "3.2.1",
-        "promise-retry": "1.1.1"
+        "promise-retry": "1.1.1",
+        "lodash": ">=4.17.13"
     },
     "scripts": {
         "build": "rimraf ui/dist && tsc",


### PR DESCRIPTION
Does not really affects us as lodash is only used in tests but anyway
updating the dependency to deal with the discovered vulnerability: https://github.com/lodash/lodash/pull/4336