### PR TITLE
Premium syncing improvements

### DIFF
--- a/rotkehlchen/data_handler.py
+++ b/rotkehlchen/data_handler.py
@@ -417,7 +417,10 @@ class DataHandler():
     def decompress_and_decrypt_db(self, password: str, encrypted_data: B64EncodedString) -> None:
         """Decrypt and decompress the encrypted data we receive from the server
 
-        If successful then replace our local Database"""
+        If successful then replace our local Database
+
+        Can raise UnableToDecryptRemoteData due to decrypt().
+        """
         log.info('Decompress and decrypt DB')
 
         # First make a backup of the DB we are about to replace

--- a/rotkehlchen/data_handler.py
+++ b/rotkehlchen/data_handler.py
@@ -23,6 +23,8 @@ from rotkehlchen.order_formatting import Trade, get_pair_position_asset, trade_t
 from rotkehlchen.typing import (
     ApiKey,
     ApiSecret,
+    B64EncodedBytes,
+    B64EncodedString,
     BlockchainAddress,
     EthAddress,
     FiatAsset,
@@ -392,7 +394,7 @@ class DataHandler():
     def delete_external_trade(self, trade_id: int) -> Tuple[bool, str]:
         return self.db.delete_external_trade(trade_id)
 
-    def compress_and_encrypt_db(self, password: str) -> Tuple[bytes, str]:
+    def compress_and_encrypt_db(self, password: str) -> Tuple[B64EncodedBytes, str]:
         """Decrypt the DB, dump in temporary plaintextdb, compress it,
         and then re-encrypt it
 
@@ -410,9 +412,9 @@ class DataHandler():
         compressed_data = zlib.compress(data_blob, level=9)
         encrypted_data = encrypt(password.encode(), compressed_data)
 
-        return encrypted_data.encode(), original_data_hash
+        return B64EncodedBytes(encrypted_data.encode()), original_data_hash
 
-    def decompress_and_decrypt_db(self, password: str, encrypted_data: str) -> None:
+    def decompress_and_decrypt_db(self, password: str, encrypted_data: B64EncodedString) -> None:
         """Decrypt and decompress the encrypted data we receive from the server
 
         If successful then replace our local Database"""

--- a/rotkehlchen/errors.py
+++ b/rotkehlchen/errors.py
@@ -34,6 +34,10 @@ class IncorrectApiKeyFormat(Exception):
     pass
 
 
+class UnableToDecryptRemoteData(Exception):
+    pass
+
+
 class RotkehlchenPermissionError(Exception):
     pass
 

--- a/rotkehlchen/premium/premium.py
+++ b/rotkehlchen/premium/premium.py
@@ -83,7 +83,8 @@ class Premium():
         self.status = SubscriptionStatus.UNKNOWN
         self.session = requests.session()
         self.apiversion = '1'
-        self.uri = 'http://localhost:5002/api/{}/'.format(self.apiversion)
+        self.uri = 'http://localhost/api/{}/'.format(self.apiversion)
+        # self.uri = 'https://rotkehlchen.io/api/{}/'.format(self.apiversion)
         self.reset_credentials(api_key, api_secret)
 
     def reset_credentials(self, api_key: ApiKey, api_secret: ApiSecret) -> None:

--- a/rotkehlchen/premium/sync.py
+++ b/rotkehlchen/premium/sync.py
@@ -110,6 +110,9 @@ class PremiumSyncManager():
         Performs syncing of data from server and replaces local db
 
         Returns true for success and False for error/failure
+
+        Can raise UnableToDecryptRemoteData due to decompress_and_decrypt_db.
+        We let it bubble up so that it can be handled by the uper layer.
         """
         try:
             result = self.premium.pull_data()

--- a/rotkehlchen/premium/sync.py
+++ b/rotkehlchen/premium/sync.py
@@ -1,0 +1,259 @@
+import base64
+import logging
+import os
+import shutil
+from enum import Enum
+from typing import NamedTuple
+
+from typing_extensions import Literal
+
+from rotkehlchen.data_handler import DataHandler
+from rotkehlchen.errors import (
+    AuthenticationError,
+    IncorrectApiKeyFormat,
+    RemoteError,
+    RotkehlchenPermissionError,
+)
+from rotkehlchen.logging import RotkehlchenLogsAdapter
+from rotkehlchen.premium.premium import Premium, premium_create_and_verify
+from rotkehlchen.typing import ApiKey, ApiSecret
+from rotkehlchen.utils.misc import ts_now, tsToDate
+
+logger = logging.getLogger(__name__)
+log = RotkehlchenLogsAdapter(logger)
+
+
+class CanSync(Enum):
+    YES = 0
+    NO = 1
+    ASK_USER = 2
+
+
+class SyncCheckResult(NamedTuple):
+    # The result of the sync check
+    can_sync: CanSync
+    # If result is ASK_USER, what should the message be?
+    message: str
+
+
+class PremiumSyncManager():
+
+    def __init__(self, data: DataHandler, password: str):
+        self.last_data_upload_ts = 0
+        self.data = data
+        self.password = password
+        self.premium = None
+
+    def _can_sync_data_from_server(self, new_account: bool) -> SyncCheckResult:
+        """
+        Checks if the remote data can be pulled from the server.
+
+        Returns a SyncCheckResult denoting whether we can pull for sure,
+        whether we can't pull or whether the user should be asked. If the user
+        should be asked a message is also returned
+        """
+        log.debug('can sync data from server -- start')
+        b64_encoded_data, our_hash = self.data.compress_and_encrypt_db(self.password)
+        try:
+            metadata = self.premium.query_last_data_metadata()
+        except RemoteError as e:
+            log.debug('can sync data from server failed', error=str(e))
+            return SyncCheckResult(can_sync=CanSync.NO, message='')
+
+        if new_account:
+            return SyncCheckResult(can_sync=CanSync.YES, message='')
+
+        if not self.data.db.get_premium_sync():
+            # If it's not a new account and the db setting for premium syncin is off stop
+            return SyncCheckResult(can_sync=CanSync.NO, message='')
+
+        log.debug(
+            'CAN_PULL',
+            ours=our_hash,
+            theirs=metadata.data_hash,
+        )
+        if our_hash == metadata.data_hash:
+            log.debug('sync from server -- same hash')
+            # same hash -- no need to get anything
+            return SyncCheckResult(can_sync=CanSync.NO, message='')
+
+        our_last_write_ts = self.data.db.get_last_write_ts()
+        if our_last_write_ts >= metadata.last_modify_ts:
+            # Local DB is newer than Server DB
+            log.debug('sync from server -- local DB more recent than remote')
+            return SyncCheckResult(can_sync=CanSync.NO, message='')
+
+        data_bytes_size = len(base64.b64decode(b64_encoded_data))
+        if data_bytes_size > metadata.data_size:
+            message_prefix = (
+                'Detected newer remote database BUT with smaller size than the local one. '
+            )
+
+        else:
+            message_prefix = 'Detected newer remote database. '
+
+        message = (
+            f'{message_prefix}'
+            f'Local size: {data_bytes_size} Remote size: {metadata.data_size} '
+            f'Local last modified time: {tsToDate(our_last_write_ts)} '
+            f'Remote last modified time: {tsToDate(metadata.last_modify_ts)} '
+            f'Would you like to replace the local DB with the remote one?'
+        )
+        return SyncCheckResult(
+            can_sync=CanSync.ASK_USER,
+            message=message,
+        )
+
+    def _sync_data_from_server_and_replace_local(self) -> bool:
+        """
+        Performs syncing of data from server and replaces local db
+
+        Returns true for success and False for error/failure
+        """
+        try:
+            result = self.premium.pull_data()
+        except RemoteError as e:
+            log.debug('sync from server -- pulling failed.', error=str(e))
+            return False
+
+        self.data.decompress_and_decrypt_db(self.password, result['data'])
+        return True
+
+    def maybe_upload_data_to_server(self) -> None:
+        log.debug('maybe upload to server -- start')
+        # if user has no premium do nothing
+        if not self.premium:
+            return
+
+        # upload only once per hour
+        diff = ts_now() - self.last_data_upload_ts
+        if diff < 3600:
+            return
+
+        data, our_hash = self.data.compress_and_encrypt_db(self.password)
+        try:
+            metadata = self.premium.query_last_data_metadata()
+        except RemoteError as e:
+            log.debug(
+                'upload to server -- query last metadata failed',
+                error=str(e),
+            )
+            return
+
+        log.debug(
+            'CAN_PUSH',
+            ours=our_hash,
+            theirs=metadata.data_hash,
+        )
+        if our_hash == metadata.data_hash:
+            log.debug('upload to server -- same hash')
+            # same hash -- no need to upload anything
+            return
+
+        our_last_write_ts = self.data.db.get_last_write_ts()
+        if our_last_write_ts <= metadata.last_modify_ts:
+            # Server's DB was modified after our local DB
+            log.debug("CAN_PUSH -> 3")
+            log.debug('upload to server -- remote db more recent than local')
+            return
+
+        try:
+            self.premium.upload_data(
+                data_blob=data,
+                our_hash=our_hash,
+                last_modify_ts=our_last_write_ts,
+                compression_type='zlib',
+            )
+        except RemoteError as e:
+            log.debug('upload to server -- upload error', error=str(e))
+            return
+
+        # update the last data upload value
+        self.last_data_upload_ts = ts_now()
+        self.data.db.update_last_data_upload_ts(self.last_data_upload_ts)
+        log.debug('upload to server -- success')
+
+    def try_premium_at_start(
+            self,
+            api_key: ApiKey,
+            api_secret: ApiSecret,
+            username: str,
+            create_new: bool,
+            sync_approval: Literal['yes', 'no', 'unknown'],
+    ) -> Premium:
+        """
+        Check if new user provided api pair or we already got one in the DB
+
+        Returns the created premium if user's premium credentials were fine.
+
+        If not it will raise AuthenticationError.
+        """
+
+        if api_key != '':
+            assert create_new, 'We should never get here for an already existing account'
+
+            try:
+                self.premium = premium_create_and_verify(api_key, api_secret)
+            except (IncorrectApiKeyFormat, AuthenticationError) as e:
+                log.error('Given API key is invalid')
+                # At this point we are at a new user trying to create an account with
+                # premium API keys and we failed. But a directory was created. Remove it.
+                # But create a backup of it in case something went really wrong
+                # and the directory contained data we did not want to lose
+                shutil.move(
+                    self.data.user_directory,
+                    os.path.join(
+                        self.data.data_directory,
+                        f'auto_backup_{username}_{ts_now()}',
+                    ),
+                )
+                shutil.rmtree(self.data.user_directory)
+                raise AuthenticationError(
+                    'Could not verify keys for the new account. '
+                    '{}'.format(str(e)),
+                )
+
+        # else, if we got premium data in the DB initialize it and try to sync with the server
+        premium_credentials = self.data.db.get_rotkehlchen_premium()
+        if premium_credentials:
+            assert not create_new, 'We should never get here for a new account'
+            api_key = premium_credentials[0]
+            api_secret = premium_credentials[1]
+            try:
+                self.premium = premium_create_and_verify(api_key, api_secret)
+            except (IncorrectApiKeyFormat, AuthenticationError) as e:
+                message = (
+                    f'Could not authenticate with the rotkehlchen server with '
+                    f'the API keys found in the Database. Error: {str(e)}'
+                )
+                log.error(message)
+                raise AuthenticationError(message)
+
+        result = self._can_sync_data_from_server(new_account=create_new)
+        if result.can_sync == CanSync.ASK_USER:
+            if sync_approval == 'unknown':
+                log.info('DB data at server newer than local')
+                raise RotkehlchenPermissionError(result.message)
+            elif sync_approval == 'yes':
+                log.info('User approved data sync from server')
+                if self._sync_data_from_server_and_replace_local():
+                    if create_new:
+                        # if we successfully synced data from the server and this is
+                        # a new account, make sure the api keys are properly stored
+                        # in the DB
+                        self.data.db.set_rotkehlchen_premium(api_key, api_secret)
+            else:
+                log.debug('Could sync data from server but user refused')
+        elif result.can_sync == CanSync.YES:
+            log.info('User approved data sync from server')
+            if self._sync_data_from_server_and_replace_local():
+                if create_new:
+                    # if we successfully synced data from the server and this is
+                    # a new account, make sure the api keys are properly stored
+                    # in the DB
+                    self.data.db.set_rotkehlchen_premium(api_key, api_secret)
+
+        # else result.can_sync was no, so we do nothing
+
+        # Success, return premium
+        return self.premium

--- a/rotkehlchen/premium/sync.py
+++ b/rotkehlchen/premium/sync.py
@@ -53,6 +53,9 @@ class PremiumSyncManager():
         should be asked a message is also returned
         """
         log.debug('can sync data from server -- start')
+        if not self.premium:
+            return SyncCheckResult(can_sync=CanSync.NO, message='')
+
         b64_encoded_data, our_hash = self.data.compress_and_encrypt_db(self.password)
 
         try:

--- a/rotkehlchen/rotkehlchen.py
+++ b/rotkehlchen/rotkehlchen.py
@@ -244,7 +244,8 @@ class Rotkehlchen():
         if not self.premium:
             return
 
-        if self.can_sync_data_from_server():
+        # If this is a new account with premium keys unconditionally try to pull
+        if create_new or self.can_sync_data_from_server():
             if sync_approval == 'unknown' and not create_new:
                 log.info('DB data at server newer than local')
                 raise RotkehlchenPermissionError(

--- a/rotkehlchen/rotkehlchen.py
+++ b/rotkehlchen/rotkehlchen.py
@@ -430,12 +430,12 @@ class Rotkehlchen():
         log.debug('upload to server -- success')
 
     def can_sync_data_from_server(self) -> bool:
-        log.debug('sync data from server -- start')
+        log.debug('can sync data from server -- start')
         _, our_hash = self.data.compress_and_encrypt_db(self.password)
         try:
-            result = self.premium.query_last_data_metadata()
+            metadata = self.premium.query_last_data_metadata()
         except RemoteError as e:
-            log.debug('sync data from server failed', error=str(e))
+            log.debug('can sync data from server failed', error=str(e))
             return False
 
         if not self.data.db.get_premium_sync():
@@ -444,15 +444,15 @@ class Rotkehlchen():
         log.debug(
             'CAN_PULL',
             ours=our_hash,
-            theirs=result['data_hash'],
+            theirs=metadata.data_hash,
         )
-        if our_hash == result['data_hash']:
+        if our_hash == metadata.data_hash:
             log.debug('sync from server -- same hash')
             # same hash -- no need to get anything
             return False
 
         our_last_write_ts = self.data.db.get_last_write_ts()
-        if our_last_write_ts >= result['last_modify_ts']:
+        if our_last_write_ts >= metadata.last_modify_ts:
             # Local DB is newer than Server DB
             log.debug('sync from server -- local DB more recent than remote')
             return False

--- a/rotkehlchen/tests/db/test_db.py
+++ b/rotkehlchen/tests/db/test_db.py
@@ -94,6 +94,7 @@ def test_export_import_db(data_dir, username):
     data.set_fiat_balance('EUR', '10')
 
     encoded_data, _ = data.compress_and_encrypt_db('123')
+
     # The server would return them decoded
     encoded_data = encoded_data.decode()
     data.decompress_and_decrypt_db('123', encoded_data)

--- a/rotkehlchen/tests/test_premium.py
+++ b/rotkehlchen/tests/test_premium.py
@@ -1,118 +1,17 @@
 import base64
-import os
 from unittest.mock import patch
 
 from rotkehlchen.constants import ROTKEHLCHEN_SERVER_TIMEOUT
 from rotkehlchen.constants.assets import A_USD
 from rotkehlchen.premium import Premium
-from rotkehlchen.tests.utils.constants import A_GBP
 from rotkehlchen.tests.utils.factories import make_random_b64bytes
 from rotkehlchen.tests.utils.mock import MockResponse
-from rotkehlchen.typing import ApiKey, ApiSecret
+from rotkehlchen.tests.utils.premium import (
+    assert_db_got_replaced,
+    create_patched_premium_session_get,
+    setup_starting_environment,
+)
 from rotkehlchen.utils.misc import ts_now
-
-# Remote data containing a different main currency (GBP)
-REMOTE_DATA = b'qLQdzIvX6c8jJyucladYh2wZvpPbna/hmokjLu8NX64blb+lM/HxIGtCq5YH9TNUV51VHGMqMBhUeHqdtdOh1/VLg5q2NuzNmiCUroV0u97YMYM5dsGrKpy+J9d1Hbq33dlx8YcQxBsJEM2lSmLXiW8DQ/AfNJfT7twe6u+w1i9soFF7hbkafnrg2s7QGukB8D4CY1sIcZd2VRlMy7ATwtOF9ur8KDrKfVpZSQlTsWfyfiWyJmcVTmvPjqPAmZ0PEDlwqmNETe6yeRnkKgU0T2xTrTAJkawoGn41g0LnYi+ghTBPTboiLVTqASk/C71ofdEjN0gacy/9wNIBrq3cvfZBsrTpjzt88W2pnPHbLdfxrycToeGKNBASexs42uzBWOqa6BFPEiy7mSzKClLp4q+hiZtasyhnwMzUYvsIb25BvXBAPJQnjcBW+hzuiwQp+C3hynxTSPY1v2S80i3fqDK7BKY8VpPpjV+tC5B0pn6PsBETKZjB1pPKQ//m/I8HI0bWb+0fpVs4NbK9nFpRN6Capd8wJTzWtSp7vGbHOoaDAwtNtp61QI7eDsiMZGYXFy5jn8CmE+uWC4zDhLmoAUwAehuUSjv0v5RJGX/IAgWxoRMhAEra54bRwZ0vY1YRBS/Xf/AXp17BRzqE8NwSAUstgizOk7ryT3BQaTqybrt4y4omyw1VVpeisJROVK0fcFJFFH1zYUbbUB+0CBRq20y54faSSNNjc05pYHv456BBBIwpUwMS4M7yZz+HwP8b/OIq0LMr7d5SJdDjG9Ut1siZbaGRdyqv86WNTiSrlMmTASHi7+z+Z8CX9GnmEgVJna5mvvOhBC/zIpZiRLzwbYjdvrtw3N9X+NHzIaDGrAo1LtWh+eGmRHPKlb+CICOMj4TGvtGKlL/IfzBcrBfeTwkNSge2l4mOFG9l82ci4RZ7I4Yr6WUQJ+NU6DYQYKb5wMz+xTJmenHHaQxy0fsTulO5/RKfY8u1O9xT5kDtNc/R00CDheqcTS773NLDL4dqHEE/+lVxoVdFT/VvxzHrBKnI6M1UyJgDHu1BFIto2/z2wS0GjVXkBVFvMfQTYMZmb88RP/04F00kt3wqg/lrhAqr60BaC/FzIKG9lepDXXBAhHZyy+a1HYCkJlA43QoX3duu3fauViP+2RN306/tFw6HJvkRiCU7E3T9tLOHU508PLhcN8a5ON7aVyBtzdGO5i57j6Xm96di79IsfwStowS31kDix+B1mYeD8R1nvthWOKgL2KiAl/UpbXDPOuVBYubZ+V4/D8jxRCivM2ukME+SCIGzraR3EBqAdvjp3dLC1tomnawaEzAQYTUHbHndYatmIYnzEsTzFd8OWoX/gy0KGaZJ/mUGDTFBbkWIDE8='  # noqa: E501
-
-
-def patched_create_premium(
-        api_key: ApiKey,
-        api_secret: ApiSecret,
-        patch_get: bool,
-        metadata_last_modify_ts=None,
-        metadata_data_hash=None,
-        saved_data=None,
-):
-    premium = Premium(
-        api_key=api_key,
-        api_secret=api_secret,
-    )
-    patched_get = None
-    if patch_get:
-        patched_get = create_patched_premium_session_get(
-            session=premium.session,
-            metadata_last_modify_ts=metadata_last_modify_ts,
-            metadata_data_hash=metadata_data_hash,
-            saved_data=saved_data,
-        )
-    patched_premium = patch(
-        # note the patch location is in rotkehlchen.py
-        'rotkehlchen.rotkehlchen.premium_create_and_verify',
-        return_value=premium,
-    )
-
-    return patched_premium, patched_get
-
-
-def mock_query_last_metadata(last_modify_ts, data_hash):
-    def do_mock_query_last_metadata(url, data, timeout):  # pylint: disable=unused-argument
-        assert len(data) == 1
-        assert 'nonce' in data
-        assert timeout == ROTKEHLCHEN_SERVER_TIMEOUT
-        payload = (
-            f'{{"upload_ts": 1337, '
-            f'"last_modify_ts": {last_modify_ts}, '
-            f'"data_hash": "{data_hash}"}}'
-        )
-        return MockResponse(200, payload)
-
-    return do_mock_query_last_metadata
-
-
-def mock_get_saved_data(saved_data):
-    def do_mock_get_saved_data(url, data, timeout):  # pylint: disable=unused-argument
-        assert len(data) == 1
-        assert 'nonce' in data
-        assert timeout == ROTKEHLCHEN_SERVER_TIMEOUT
-        payload = f'{{"data": "{saved_data.decode()}"}}'
-        return MockResponse(200, payload)
-
-    return do_mock_get_saved_data
-
-
-def create_patched_premium_session_get(
-        session,
-        metadata_last_modify_ts,
-        metadata_data_hash,
-        saved_data,
-):
-    def mocked_get(url, data, timeout):
-        if 'last_data_metadata' in url:
-            implementation = mock_query_last_metadata(
-                last_modify_ts=metadata_last_modify_ts,
-                data_hash=metadata_data_hash,
-            )
-        elif 'get_saved_data' in url:
-            implementation = mock_get_saved_data(saved_data=saved_data)
-        else:
-            raise ValueError('Unmocked url in session get for premium')
-
-        return implementation(url, data, timeout)
-
-    return patch.object(
-        session,
-        'get',
-        side_effect=mocked_get,
-    )
-
-
-def create_patched_premium_with_keypair(
-        patch_get: bool,
-        metadata_last_modify_ts=None,
-        metadata_data_hash=None,
-        saved_data=None,
-):
-    api_key = ApiKey(base64.b64encode(make_random_b64bytes(128)))
-    api_secret = ApiSecret(base64.b64encode(make_random_b64bytes(128)))
-    patches = patched_create_premium(
-        api_key,
-        api_secret,
-        patch_get,
-        metadata_last_modify_ts,
-        metadata_data_hash,
-        saved_data,
-    )
-    return api_key, api_secret, patches[0], patches[1]
 
 
 def test_upload_data_to_server(rotkehlchen_instance, username, db_password):
@@ -209,145 +108,90 @@ def test_upload_data_to_server_same_hash(rotkehlchen_instance, db_password):
         assert not put_mock.called
 
 
-# TODO: Seems that the premium_should_sync option is not used. Write test for it
 def test_try_premium_at_start_new_account_can_pull_data(
         rotkehlchen_instance,
         username,
         db_password,
 ):
-    # Set the can_sync setting to true
-    rotkehlchen_instance.data.db.update_premium_sync(True)
-    our_last_write_ts = rotkehlchen_instance.data.db.get_last_write_ts()
-    assert rotkehlchen_instance.data.db.get_main_currency() == A_USD
-    _, our_hash = rotkehlchen_instance.data.compress_and_encrypt_db(db_password)
-
-    # remote hash should be different
-    remote_hash = 'a' + our_hash[1:]
-    remote_data = REMOTE_DATA
-    api_key, api_secret, patched_premium, patched_get = create_patched_premium_with_keypair(
-        patch_get=True,
-        metadata_last_modify_ts=our_last_write_ts + 10,  # Remote DB is newer
-        metadata_data_hash=remote_hash,
-        saved_data=remote_data,
+    # Test that even with can_sync False, at start of new account we attempt data pull
+    setup_starting_environment(
+        rotkehlchen_instance=rotkehlchen_instance,
+        username=username,
+        db_password=db_password,
+        first_time=True,
+        same_hash_with_remote=False,
+        newer_remote_db=True,
+        db_can_sync_setting=False,
     )
-
-    with patched_premium, patched_get:
-        rotkehlchen_instance.try_premium_at_start(
-            api_key=api_key,
-            api_secret=api_secret,
-            username=username,
-            create_new=True,
-            sync_approval='yes',
-        )
-
-    # At this point pulling data from rotkehlchen server should have worked
-    # and our database should have been replaced. The new data have different
-    # main currency
-    assert rotkehlchen_instance.data.db.get_main_currency() == A_GBP
-    # Also check a copy of our old DB is kept around.
-    directory = os.path.join(rotkehlchen_instance.data.data_directory, username)
-    files = list(os.path.join(directory, f) for f in os.listdir(directory))
-    assert len(files) == 2
-    # The order of the files is not guaranteed
-    assert 'rotkehlchen.db' in files[0] or 'rotkehlchen.db' in files[1]
-    assert 'backup' in files[0] or 'backup' in files[1]
+    assert_db_got_replaced(rotkehlchen_instance=rotkehlchen_instance, username=username)
 
 
-def test_try_premium_at_start_new_account_same_hash(
+def test_try_premium_at_start_old_account_can_pull_data(
         rotkehlchen_instance,
         username,
         db_password,
 ):
-    our_last_write_ts = rotkehlchen_instance.data.db.get_last_write_ts()
-    assert rotkehlchen_instance.data.db.get_main_currency() == A_USD
-    _, our_hash = rotkehlchen_instance.data.compress_and_encrypt_db(db_password)
-
-    # same hash, nothing should happen
-    remote_hash = our_hash
-    remote_data = REMOTE_DATA
-    api_key, api_secret, patched_premium, patched_get = create_patched_premium_with_keypair(
-        patch_get=True,
-        metadata_last_modify_ts=our_last_write_ts + 10,  # Remote DB is newer
-        metadata_data_hash=remote_hash,
-        saved_data=remote_data,
+    setup_starting_environment(
+        rotkehlchen_instance=rotkehlchen_instance,
+        username=username,
+        db_password=db_password,
+        first_time=False,
+        same_hash_with_remote=False,
+        newer_remote_db=True,
+        db_can_sync_setting=True,
     )
+    assert_db_got_replaced(rotkehlchen_instance=rotkehlchen_instance, username=username)
 
-    with patched_premium, patched_get:
-        rotkehlchen_instance.try_premium_at_start(
-            api_key=api_key,
-            api_secret=api_secret,
-            username=username,
-            create_new=True,
-            sync_approval='yes',
-        )
 
+def test_try_premium_at_start_old_account_doesnt_pull_data_with_no_premium_sync(
+        rotkehlchen_instance,
+        username,
+        db_password,
+):
+    setup_starting_environment(
+        rotkehlchen_instance=rotkehlchen_instance,
+        username=username,
+        db_password=db_password,
+        first_time=False,
+        same_hash_with_remote=False,
+        newer_remote_db=True,
+        db_can_sync_setting=False,
+    )
     # DB should not have changed
     assert rotkehlchen_instance.data.db.get_main_currency() == A_USD
 
 
-def test_try_premium_at_start_new_account_older_remote_ts(
+def test_try_premium_at_start_old_account_same_hash(
         rotkehlchen_instance,
         username,
         db_password,
 ):
-    # Set the can_sync setting to true
-    rotkehlchen_instance.data.db.update_premium_sync(True)
-    our_last_write_ts = rotkehlchen_instance.data.db.get_last_write_ts()
-    assert rotkehlchen_instance.data.db.get_main_currency() == A_USD
-    _, our_hash = rotkehlchen_instance.data.compress_and_encrypt_db(db_password)
-
-    # remote hash should be different
-    remote_hash = 'a' + our_hash[1:]
-    remote_data = REMOTE_DATA
-    api_key, api_secret, patched_premium, patched_get = create_patched_premium_with_keypair(
-        patch_get=True,
-        metadata_last_modify_ts=our_last_write_ts - 10,  # Remote DB is older
-        metadata_data_hash=remote_hash,
-        saved_data=remote_data,
+    setup_starting_environment(
+        rotkehlchen_instance=rotkehlchen_instance,
+        username=username,
+        db_password=db_password,
+        first_time=False,
+        same_hash_with_remote=True,
+        newer_remote_db=True,
+        db_can_sync_setting=True,
     )
-
-    with patched_premium, patched_get:
-        rotkehlchen_instance.try_premium_at_start(
-            api_key=api_key,
-            api_secret=api_secret,
-            username=username,
-            create_new=True,
-            sync_approval='yes',
-        )
-
     # DB should not have changed
     assert rotkehlchen_instance.data.db.get_main_currency() == A_USD
 
 
-def test_try_premium_at_start_new_account_no_sync(
+def test_try_premium_at_start_old_account_older_remote_ts(
         rotkehlchen_instance,
         username,
         db_password,
 ):
-    # Set the can_sync setting to false
-    rotkehlchen_instance.data.db.update_premium_sync(False)
-    our_last_write_ts = rotkehlchen_instance.data.db.get_last_write_ts()
-    assert rotkehlchen_instance.data.db.get_main_currency() == A_USD
-    _, our_hash = rotkehlchen_instance.data.compress_and_encrypt_db(db_password)
-
-    # remote hash should be different
-    remote_hash = 'a' + our_hash[1:]
-    remote_data = REMOTE_DATA
-    api_key, api_secret, patched_premium, patched_get = create_patched_premium_with_keypair(
-        patch_get=True,
-        metadata_last_modify_ts=our_last_write_ts + 10,  # Remote DB is newer
-        metadata_data_hash=remote_hash,
-        saved_data=remote_data,
+    setup_starting_environment(
+        rotkehlchen_instance=rotkehlchen_instance,
+        username=username,
+        db_password=db_password,
+        first_time=False,
+        same_hash_with_remote=False,
+        newer_remote_db=False,
+        db_can_sync_setting=True,
     )
-
-    with patched_premium, patched_get:
-        rotkehlchen_instance.try_premium_at_start(
-            api_key=api_key,
-            api_secret=api_secret,
-            username=username,
-            create_new=True,
-            sync_approval='yes',
-        )
-
     # DB should not have changed
     assert rotkehlchen_instance.data.db.get_main_currency() == A_USD

--- a/rotkehlchen/tests/utils/premium.py
+++ b/rotkehlchen/tests/utils/premium.py
@@ -1,0 +1,195 @@
+import base64
+import os
+from unittest.mock import patch
+
+from rotkehlchen.constants import ROTKEHLCHEN_SERVER_TIMEOUT
+from rotkehlchen.constants.assets import A_USD
+from rotkehlchen.premium import Premium
+from rotkehlchen.rotkehlchen import Rotkehlchen
+from rotkehlchen.tests.utils.constants import A_GBP
+from rotkehlchen.tests.utils.factories import make_random_b64bytes
+from rotkehlchen.tests.utils.mock import MockResponse
+from rotkehlchen.typing import ApiKey, ApiSecret
+
+# Remote data containing a different main currency (GBP)
+REMOTE_DATA = b'qLQdzIvX6c8jJyucladYh2wZvpPbna/hmokjLu8NX64blb+lM/HxIGtCq5YH9TNUV51VHGMqMBhUeHqdtdOh1/VLg5q2NuzNmiCUroV0u97YMYM5dsGrKpy+J9d1Hbq33dlx8YcQxBsJEM2lSmLXiW8DQ/AfNJfT7twe6u+w1i9soFF7hbkafnrg2s7QGukB8D4CY1sIcZd2VRlMy7ATwtOF9ur8KDrKfVpZSQlTsWfyfiWyJmcVTmvPjqPAmZ0PEDlwqmNETe6yeRnkKgU0T2xTrTAJkawoGn41g0LnYi+ghTBPTboiLVTqASk/C71ofdEjN0gacy/9wNIBrq3cvfZBsrTpjzt88W2pnPHbLdfxrycToeGKNBASexs42uzBWOqa6BFPEiy7mSzKClLp4q+hiZtasyhnwMzUYvsIb25BvXBAPJQnjcBW+hzuiwQp+C3hynxTSPY1v2S80i3fqDK7BKY8VpPpjV+tC5B0pn6PsBETKZjB1pPKQ//m/I8HI0bWb+0fpVs4NbK9nFpRN6Capd8wJTzWtSp7vGbHOoaDAwtNtp61QI7eDsiMZGYXFy5jn8CmE+uWC4zDhLmoAUwAehuUSjv0v5RJGX/IAgWxoRMhAEra54bRwZ0vY1YRBS/Xf/AXp17BRzqE8NwSAUstgizOk7ryT3BQaTqybrt4y4omyw1VVpeisJROVK0fcFJFFH1zYUbbUB+0CBRq20y54faSSNNjc05pYHv456BBBIwpUwMS4M7yZz+HwP8b/OIq0LMr7d5SJdDjG9Ut1siZbaGRdyqv86WNTiSrlMmTASHi7+z+Z8CX9GnmEgVJna5mvvOhBC/zIpZiRLzwbYjdvrtw3N9X+NHzIaDGrAo1LtWh+eGmRHPKlb+CICOMj4TGvtGKlL/IfzBcrBfeTwkNSge2l4mOFG9l82ci4RZ7I4Yr6WUQJ+NU6DYQYKb5wMz+xTJmenHHaQxy0fsTulO5/RKfY8u1O9xT5kDtNc/R00CDheqcTS773NLDL4dqHEE/+lVxoVdFT/VvxzHrBKnI6M1UyJgDHu1BFIto2/z2wS0GjVXkBVFvMfQTYMZmb88RP/04F00kt3wqg/lrhAqr60BaC/FzIKG9lepDXXBAhHZyy+a1HYCkJlA43QoX3duu3fauViP+2RN306/tFw6HJvkRiCU7E3T9tLOHU508PLhcN8a5ON7aVyBtzdGO5i57j6Xm96di79IsfwStowS31kDix+B1mYeD8R1nvthWOKgL2KiAl/UpbXDPOuVBYubZ+V4/D8jxRCivM2ukME+SCIGzraR3EBqAdvjp3dLC1tomnawaEzAQYTUHbHndYatmIYnzEsTzFd8OWoX/gy0KGaZJ/mUGDTFBbkWIDE8='  # noqa: E501
+
+
+def mock_query_last_metadata(last_modify_ts, data_hash):
+    def do_mock_query_last_metadata(url, data, timeout):  # pylint: disable=unused-argument
+        assert len(data) == 1
+        assert 'nonce' in data
+        assert timeout == ROTKEHLCHEN_SERVER_TIMEOUT
+        payload = (
+            f'{{"upload_ts": 1337, '
+            f'"last_modify_ts": {last_modify_ts}, '
+            f'"data_hash": "{data_hash}",'
+            f'"data_size": {len(base64.b64decode(REMOTE_DATA))}}}'
+        )
+        return MockResponse(200, payload)
+
+    return do_mock_query_last_metadata
+
+
+def mock_get_saved_data(saved_data):
+    def do_mock_get_saved_data(url, data, timeout):  # pylint: disable=unused-argument
+        assert len(data) == 1
+        assert 'nonce' in data
+        assert timeout == ROTKEHLCHEN_SERVER_TIMEOUT
+        payload = f'{{"data": "{saved_data.decode()}"}}'
+        return MockResponse(200, payload)
+
+    return do_mock_get_saved_data
+
+
+def create_patched_premium_session_get(
+        session,
+        metadata_last_modify_ts,
+        metadata_data_hash,
+        saved_data,
+):
+    def mocked_get(url, data, timeout):
+        if 'last_data_metadata' in url:
+            implementation = mock_query_last_metadata(
+                last_modify_ts=metadata_last_modify_ts,
+                data_hash=metadata_data_hash,
+            )
+        elif 'get_saved_data' in url:
+            implementation = mock_get_saved_data(saved_data=saved_data)
+        else:
+            raise ValueError('Unmocked url in session get for premium')
+
+        return implementation(url, data, timeout)
+
+    return patch.object(
+        session,
+        'get',
+        side_effect=mocked_get,
+    )
+
+
+def patched_create_premium(
+        api_key: ApiKey,
+        api_secret: ApiSecret,
+        patch_get: bool,
+        metadata_last_modify_ts=None,
+        metadata_data_hash=None,
+        saved_data=None,
+):
+    premium = Premium(
+        api_key=api_key,
+        api_secret=api_secret,
+    )
+    patched_get = None
+    if patch_get:
+        patched_get = create_patched_premium_session_get(
+            session=premium.session,
+            metadata_last_modify_ts=metadata_last_modify_ts,
+            metadata_data_hash=metadata_data_hash,
+            saved_data=saved_data,
+        )
+    patched_premium = patch(
+        # note the patch location is in rotkehlchen.py
+        'rotkehlchen.rotkehlchen.premium_create_and_verify',
+        return_value=premium,
+    )
+
+    return patched_premium, patched_get
+
+
+def create_patched_premium_with_keypair(
+        patch_get: bool,
+        metadata_last_modify_ts=None,
+        metadata_data_hash=None,
+        saved_data=None,
+):
+    api_key = ApiKey(base64.b64encode(make_random_b64bytes(128)))
+    api_secret = ApiSecret(base64.b64encode(make_random_b64bytes(128)))
+    patches = patched_create_premium(
+        api_key,
+        api_secret,
+        patch_get,
+        metadata_last_modify_ts,
+        metadata_data_hash,
+        saved_data,
+    )
+    return api_key, api_secret, patches[0], patches[1]
+
+
+def setup_starting_environment(
+        rotkehlchen_instance: Rotkehlchen,
+        username: str,
+        db_password: str,
+        first_time: bool,
+        same_hash_with_remote: bool,
+        newer_remote_db: bool,
+        db_can_sync_setting: bool,
+):
+    """
+    Sets up the starting environment for premium testing when the user
+    starts up his node either for the first time or logs in an already
+    existing account
+    """
+
+    if not first_time:
+        # Emulate already having api keys in the DB
+        rotkehlchen_instance.data.db.set_rotkehlchen_premium(
+            api_key=base64.b64encode(make_random_b64bytes(128)),
+            api_secret=base64.b64encode(make_random_b64bytes(128)),
+        )
+
+    rotkehlchen_instance.data.db.update_premium_sync(db_can_sync_setting)
+    our_last_write_ts = rotkehlchen_instance.data.db.get_last_write_ts()
+    assert rotkehlchen_instance.data.db.get_main_currency() == A_USD
+    _, our_hash = rotkehlchen_instance.data.compress_and_encrypt_db(db_password)
+
+    if same_hash_with_remote:
+        remote_hash = our_hash
+    else:
+        remote_hash = 'a' + our_hash[1:]
+    remote_data = REMOTE_DATA
+
+    if newer_remote_db:
+        metadata_last_modify_ts = our_last_write_ts + 10
+    else:
+        metadata_last_modify_ts = our_last_write_ts - 10
+
+    api_key, api_secret, patched_premium, patched_get = create_patched_premium_with_keypair(
+        patch_get=True,
+        metadata_last_modify_ts=metadata_last_modify_ts,
+        metadata_data_hash=remote_hash,
+        saved_data=remote_data,
+    )
+
+    if first_time:
+        api_key = api_key
+        api_secret = api_secret
+        create_new = True
+    else:
+        api_key = ''
+        api_secret = ''
+        create_new = False
+
+    with patched_premium, patched_get:
+        rotkehlchen_instance.try_premium_at_start(
+            api_key=api_key,
+            api_secret=api_secret,
+            username=username,
+            create_new=create_new,
+            sync_approval='yes',
+        )
+
+
+def assert_db_got_replaced(rotkehlchen_instance: Rotkehlchen, username: str):
+    """For environment setup with setup_starting_environment make sure DB is replaced"""
+    # At this point pulling data from rotkehlchen server should have worked
+    # and our database should have been replaced. The new data have different
+    # main currency
+    assert rotkehlchen_instance.data.db.get_main_currency() == A_GBP
+    # Also check a copy of our old DB is kept around.
+    directory = os.path.join(rotkehlchen_instance.data.data_directory, username)
+    files = list(os.path.join(directory, f) for f in os.listdir(directory))
+    assert len(files) == 2
+    # The order of the files is not guaranteed
+    assert 'rotkehlchen.db' in files[0] or 'rotkehlchen.db' in files[1]
+    assert 'backup' in files[0] or 'backup' in files[1]

--- a/rotkehlchen/typing.py
+++ b/rotkehlchen/typing.py
@@ -16,6 +16,12 @@ ApiKey = NewType('ApiKey', T_ApiKey)
 T_ApiSecret = bytes
 ApiSecret = NewType('ApiSecret', T_ApiSecret)
 
+T_B64EncodedBytes = bytes
+B64EncodedBytes = NewType('B64EncodedBytes', T_B64EncodedBytes)
+
+T_B64EncodedString = str
+B64EncodedString = NewType('B64EncodedString', T_B64EncodedString)
+
 
 class ApiCredentials(NamedTuple):
     """Represents Credentials for various APIs. Exchanges, Premium e.t.c."""


### PR DESCRIPTION
- Lots of code refactoring around premium and premium syncing check
- Adapt to the API code change of adding data size to `query_last_metadata()`
- If this is a new account with a premium key unconditionally pull remote data
- Warn user if remote data can't be decrypted due to having been encrypted with different password
- Ask user if his local DB should be replaced and provide him with information of the remote DB so that the can make an informed decision.
- Do not upload data to server if local DB is smaller than remote