### PR TITLE
Handle actions for which no price can be found and cryptocompare query fix

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -9,6 +9,7 @@ Changelog
   - `Spin Protocol <https://coinmarketcap.com/currencies/spin-protocol/>`__
 * :feature:`428` Better handle unexpected data from external sources.
 * :bug:`76` Handle poloniex queries returning null for the fee field.
+* :bug:`432` If historical price for a trade is not found gracefully skip the trade. Also handle cryptocompare query edge case.
 
 
 * :release:`1.0.0 <2019-01-22>`

--- a/rotkehlchen/accounting/events.py
+++ b/rotkehlchen/accounting/events.py
@@ -4,8 +4,7 @@ from typing import Dict, Optional, Tuple
 from rotkehlchen.assets.asset import Asset
 from rotkehlchen.constants import BTC_BCH_FORK_TS, ETH_DAO_FORK_TS, ZERO
 from rotkehlchen.constants.assets import A_BCH, A_BTC, A_ETC, A_ETH
-from rotkehlchen.errors import PriceQueryUnknownFromAsset
-from rotkehlchen.externalapis.cryptocompare import NoPriceForGivenTimestamp
+from rotkehlchen.errors import NoPriceForGivenTimestamp, PriceQueryUnknownFromAsset
 from rotkehlchen.fval import FVal
 from rotkehlchen.history import PriceHistorian
 from rotkehlchen.logging import RotkehlchenLogsAdapter

--- a/rotkehlchen/errors.py
+++ b/rotkehlchen/errors.py
@@ -83,3 +83,12 @@ class DBUpgradeError(Exception):
 class DeserializationError(Exception):
     """Raised when deserializing data from the outside and something unexpected is found"""
     pass
+
+
+class NoPriceForGivenTimestamp(Exception):
+    def __init__(self, from_asset, to_asset, timestamp):
+        super(NoPriceForGivenTimestamp, self).__init__(
+            'Unable to query a historical price for "{}" to "{}" at {}'.format(
+                from_asset, to_asset, timestamp,
+            ),
+        )

--- a/rotkehlchen/externalapis/cryptocompare.py
+++ b/rotkehlchen/externalapis/cryptocompare.py
@@ -10,7 +10,7 @@ from rotkehlchen.assets.asset import Asset
 from rotkehlchen.constants import ZERO
 from rotkehlchen.constants.assets import A_BTC, A_USD
 from rotkehlchen.constants.cryptocompare import KNOWN_TO_MISS_FROM_CRYPTOCOMPARE
-from rotkehlchen.errors import PriceQueryUnknownFromAsset
+from rotkehlchen.errors import NoPriceForGivenTimestamp, PriceQueryUnknownFromAsset
 from rotkehlchen.fval import FVal
 from rotkehlchen.history import PriceHistorian
 from rotkehlchen.logging import RotkehlchenLogsAdapter
@@ -42,15 +42,6 @@ class PriceHistoryData(NamedTuple):
     data: List[PriceHistoryEntry]
     start_time: Timestamp
     end_time: Timestamp
-
-
-class NoPriceForGivenTimestamp(Exception):
-    def __init__(self, from_asset, to_asset, timestamp):
-        super(NoPriceForGivenTimestamp, self).__init__(
-            'Unable to query a historical price for "{}" to "{}" at {}'.format(
-                from_asset, to_asset, timestamp,
-            ),
-        )
 
 
 def _dict_history_to_entries(data: List[Dict[str, Any]]) -> List[PriceHistoryEntry]:

--- a/rotkehlchen/tests/test_cryptocompare.py
+++ b/rotkehlchen/tests/test_cryptocompare.py
@@ -56,13 +56,27 @@ def test_cryptocompare_historical_data_use_cached_price(accounting_data_dir):
     assert result[1].high == FVal(20)
 
 
+@pytest.mark.skip(
+    'Same test as test_end_to_end_tax_report::'
+    'test_unknown_cryptocompare_asset_and_price_not_found_in_history',
+)
 @pytest.mark.parametrize('use_clean_caching_directory', [True])
 @pytest.mark.parametrize('should_mock_price_queries', [False])
-def test_cryptocompare_histohour_query_old_ts_xcp(accounting_data_dir, price_historian):
+def test_cryptocompare_histohour_query_old_ts_xcp(
+        accounting_data_dir,
+        price_historian,  # pylint: disable=unused-argument
+):
     """Test that as a result of this query a crash does not happen.
 
     Regression for: https://github.com/rotkehlchenio/rotkehlchen/issues/432
     Unfortunately still no price is found so we have to expect a NoPriceForGivenTimestamp
+
+    This test is now skipped since it's a subset of:
+    test_end_to_end_tax_report::test_unknown_cryptocompare_asset_and_price_not_found_in_history
+
+    When more price data sources are introduced then this should probably be unskipped
+    to focus on the cryptocompare case. But at the moment both tests follow the same
+    path and are probably slow due to the price querying.
     """
     with pytest.raises(NoPriceForGivenTimestamp):
         cc = Cryptocompare(data_directory=accounting_data_dir)

--- a/tools/data_faker/data_faker/utils.py
+++ b/tools/data_faker/data_faker/utils.py
@@ -3,7 +3,7 @@ from typing import Callable
 from rotkehlchen.assets.asset import Asset
 from rotkehlchen.constants import ZERO
 from rotkehlchen.constants.assets import A_USD
-from rotkehlchen.externalapis.cryptocompare import NoPriceForGivenTimestamp
+from rotkehlchen.errors import NoPriceForGivenTimestamp
 from rotkehlchen.fval import FVal
 from rotkehlchen.typing import Timestamp
 


### PR DESCRIPTION
1. Fix handling of an edge case during cryptocompare queries
2. When a price can't be found for an action skip it an log an error

Should fix #432 
