### PR TITLE
Support assets that were recently added to bittrex

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,3 +2,6 @@ lint:
 	flake8 rotkehlchen/ tools/data_faker
 	mypy rotkehlchen/ tools/data_faker --ignore-missing-imports --warn-unreachable
 	pylint --rcfile .pylint.rc rotkehlchen/ tools/data_faker
+
+clean:
+	rm -rf build/ rotkehlchen_py_dist/ htmlcov/ rotkehlchen.egg-info/

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -12,7 +12,7 @@ Changelog
 * :bug:`432` If historical price for a trade is not found gracefully skip the trade. Also handle cryptocompare query edge case.
 
 
-* :release:`1.0.0 <2019-01-22>`
+* :release:`1.0.0 <2019-07-22>`
 * :bug:`420` There are no more negative percentages at tax report generation progress
 * :bug:`392` Revisiting usersettings properly updates per account tables if an account has been deleted before.
 * :bug:`325` Tracking accounts/tokens in user settings will now be immediately reflected on the dashboard.

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -7,6 +7,10 @@ Changelog
   - `Luna Coin <https://coinmarketcap.com/currencies/luna-coin/>`__
   - `Luna Terra <https://coinmarketcap.com/currencies/terra/>`__
   - `Spin Protocol <https://coinmarketcap.com/currencies/spin-protocol/>`__
+  - `Blockcloud <https://coinmarketcap.com/currencies/blockcloud/>`__
+  - `Bloc.Money <https://coinmarketcap.com/currencies/bloc-money/>`__
+  - `Chromia  <https://coinmarketcap.com/currencies/chromia/>`__
+
 * :feature:`428` Better handle unexpected data from external sources.
 * :bug:`76` Handle poloniex queries returning null for the fee field.
 * :bug:`432` If historical price for a trade is not found gracefully skip the trade. Also handle cryptocompare query edge case.

--- a/rotkehlchen/constants/cryptocompare.py
+++ b/rotkehlchen/constants/cryptocompare.py
@@ -277,6 +277,9 @@ KNOWN_TO_MISS_FROM_CRYPTOCOMPARE = (
     # BOXX (https://coinmarketcap.com/currencies/blockparty-boxx-token/)
     # is not in cryptocompare but is in paprika
     'BOXX',
+    # Block.Money is not in cryptocompare but it's in coin paprika
+    # https://coinmarketcap.com/currencies/bloc-money/
+    'BLOC-2',
     # BTCTalkCoin is not in cryptocompare but it's in coin paprika
     # https://api.coinpaprika.com/v1/coins/talk-btctalkcoin and in coinmarketcap
     # https://coinmarketcap.com/currencies/btctalkcoin/#charts

--- a/rotkehlchen/data/all_assets.json
+++ b/rotkehlchen/data/all_assets.json
@@ -1769,6 +1769,14 @@
         "symbol": "CHP",
         "type": "ethereum token"
     },
+    "CHR": {
+        "ethereum_address": "0x915044526758533dfB918ecEb6e44bc21632060D",
+        "ethereum_token_decimals": 6,
+        "name": "Chromia",
+        "started": 1558915200,
+        "symbol": "CHR",
+        "type": "ethereum token"
+    },
     "CHSB": {
         "ethereum_address": "0xba9d4199faB4f26eFE3551D490E3821486f135Ba",
         "ethereum_token_decimals": 8,

--- a/rotkehlchen/data/all_assets.json
+++ b/rotkehlchen/data/all_assets.json
@@ -1016,6 +1016,20 @@
         "symbol": "BLN",
         "type": "ethereum token"
     },
+    "BLOC": {
+        "ethereum_address": "0x6F919D67967a97EA36195A2346d9244E60FE0dDB",
+        "ethereum_token_decimals": 18,
+        "name": "Blockcloud",
+        "started": 1540598400,
+        "symbol": "BLOC",
+        "type": "ethereum token"
+    },
+    "BLOC-2": {
+        "name": "BLOC.MONEY",
+        "started": 1539736469,
+        "symbol": "BLOC",
+        "type": "own chain"
+    },
     "BLOCK": {
         "name": "Blocknet",
         "started": 1413763200,

--- a/rotkehlchen/externalapis/coinmarketcap.py
+++ b/rotkehlchen/externalapis/coinmarketcap.py
@@ -725,6 +725,9 @@ WORLD_TO_CMC_ID = {
     # For Rotkehlchen BET is Dao.Casino and BET-2 is BetaCoin
     'BET': 1771,
     'BET-2': 70,
+    # For Rotkehlchen BLOC is BlockCloud and BLOC-2 is Bloc.Money
+    'BLOC': 3860,
+    'BLOC-2': 3451,
     # For Rotkehlchen BOX is BoxToken and BOX-2 is ContentBox
     'BOX': 3475,
     'BOX-2': 2945,

--- a/rotkehlchen/externalapis/coinpaprika.py
+++ b/rotkehlchen/externalapis/coinpaprika.py
@@ -259,6 +259,9 @@ WORLD_TO_PAPRIKA_ID = {
     'BHPC': 'bhpc-bhpcash',
     # For Rotkehlcen BITPARK is BITPARK but in Paprika it's BPC
     'BITPARK': 'bpc-bitpark-coin',
+    # For Rotkehlchen BLOC is BlockCloud and BLOC-2 is Bloc.Money
+    'BLOC': 'bloc-blockcloud',
+    'BLOC-2': 'bloc-blocmoney',
     # For Rotkehlchen BOX is BoxToken and BOX-2 is ContentBox
     'BOX': 'box-box-token',
     'BOX-2': 'box-contentbox',


### PR DESCRIPTION
Adds suport for:

- https://coinmarketcap.com/currencies/chromia/ as `CHR`
- https://coinmarketcap.com/currencies/blockcloud/ as `BLOC`
- https://coinmarketcap.com/currencies/bloc-money/ as `BLOC-2`