### PR TITLE
Detect given Kraken API Key permissions and if insufficient warn user

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,6 +5,8 @@ Changelog
 * :feature:`-` Added support for the following tokens
 
   - `Contentos <https://coinmarketcap.com/currencies/contentos/>`__
+* :feature:`442` If a user provides a Kraken API key with insufficient permissions we no longer accept it and also provide them with a proper error message.
+* :bug:`443` Fix bug in deserialization of non-exact floating point kraken timestamp values which could lead to a crash during tax report generation.
 
 * :release:`1.0.1 <2019-08-02>`
 * :feature:`425` Users can now provide arguments to the backend via a config file. For more information check the `docs <https://rotkehlchen.readthedocs.io/en/latest/usage_guide.html#set-the-backend-s-arguments`__. 

--- a/rotkehlchen/kraken.py
+++ b/rotkehlchen/kraken.py
@@ -273,7 +273,12 @@ class Kraken(Exchange):
             elif 'EAPI:Invalid key' in error:
                 return False, 'Provided API Key is invalid'
             else:
-                raise
+                log.error('Kraken API key validation error: {str(e)}')
+                msg = (
+                    'Unknown error at Kraken API key validation. Perhaps API '
+                    'Key/Secret combination invalid?'
+                )
+                return False, msg
         return True, ''
 
     def _query_public(self, method: str, req: Optional[dict] = None) -> dict:


### PR DESCRIPTION
1. Properly delete kraken at unknown exception message key validation

2. When a user provides a kraken api key make sure the following
permissions are given to the key:

   - Ability to query funds
   - Ability to query open/closed trades
   - Ability to query ledgers

Fix #442 