### PR TITLE
Converts tax report start and end time to local time

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :bug:`469` Fixes error with OTC trades.
 * :bug:`463` Converts tax report start and end time to local time.
 * :feature:`465` Update the cryptocurrency icons package to 0.16.0. This gives us a lot more icons, including but not limited to an icon for DAI.
 * :bug:`467` Removing ETH tokens for which a cryptocompare query failed to find a price now work properly.

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :bug:`463` Converts tax report start and end time to local time.
 * :feature:`465` Update the cryptocurrency icons package to 0.16.0. This gives us a lot more icons, including but not limited to an icon for DAI.
 * :bug:`467` Removing ETH tokens for which a cryptocompare query failed to find a price now work properly.
 * :feature:`458` Binance users now also have their deposit/withdrawal history taken into account during profit/loss calculation.

--- a/ui/model/otc-trade.ts
+++ b/ui/model/otc-trade.ts
@@ -2,7 +2,7 @@ export interface OtcTrade {
     readonly id: number;
     readonly timestamp: number;
     readonly pair: string;
-    readonly type: string;
+    readonly trade_type: string;
     readonly amount: string;
     readonly rate: string;
     readonly fee: string;

--- a/ui/otctrades.ts
+++ b/ui/otctrades.ts
@@ -36,7 +36,7 @@ function edit_otc_trade(row: DataTables.RowMethods) {
     const ts = timestamp_to_date(data.timestamp, false);
     $('#otc_timestamp').val(ts);
     $('#otc_pair').val(data.pair);
-    $('#otc_type').val(data.type);
+    $('#otc_type').val(data.trade_type);
     $('#otc_amount').val(data.amount);
     $('#otc_rate').val(data.rate);
     $('#otc_fee').val(data.fee);
@@ -114,7 +114,7 @@ function create_otctrades_table() {
                     'width': '15px'
                 },
                 {'data': 'pair'},
-                {'data': 'type'},
+                {'data': 'trade_type'},
                 {'data': 'amount'},
                 {'data': 'rate'},
                 {

--- a/ui/utils.ts
+++ b/ui/utils.ts
@@ -202,7 +202,7 @@ export function date_text_to_utc_ts(txt: string) {
     const year = parseInt(m[2], 10);
     const hours = parseInt(m[3], 10);
     const seconds = parseInt(m[4], 10);
-    return (new Date(Date.UTC(year, month, day, hours, seconds))).getTime() / 1000;
+    return (new Date(year, month, day, hours, seconds)).getTime() / 1000;
 }
 
 interface MenuItem {


### PR DESCRIPTION
Closes #463
Closes #469 

So by making a UTC date out of the start and time and then wrapping that in a new Date would put the actual start and end date x hours (depending on the timezone) in the future.