### PR TITLE
 Fix the issue where zero-price token removal did not work

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :bug:`467` Removing ETH tokens for which a cryptocompare query failed to find a price now work properly.
 * :feature:`458` Binance users now also have their deposit/withdrawal history taken into account during profit/loss calculation.
 * :feature:`457` Bittrex users now also have their deposit/withdrawal history taken into account during profit/loss calculation.
 * :bug:`451` An assertion will no longer stop balances from being saved for some FIAT assets.

--- a/rotkehlchen/blockchain.py
+++ b/rotkehlchen/blockchain.py
@@ -171,8 +171,11 @@ class Blockchain():
                     self.balances[A_ETH][account]['usd_value'] -
                     deleting_usd_value
                 )
-
-            del self.totals[token]
+            # Remove the token from the totals iff existing. May not exist
+            #  if the token price is 0 but is still tracked.
+            # See https://github.com/rotkehlchenio/rotkehlchen/issues/467
+            # for more details
+            self.totals.pop(token, None)
             self.owned_eth_tokens.remove(token)
 
         return {'per_account': self.balances, 'totals': self.totals}


### PR DESCRIPTION
Having had a zero price returned for a token (like the `PRL` in #467)
does not add the token to the totals.

This way when the token removal is attempted, trying to remove it from
the totals results into a key error which interrupts the worker thread
and does not end up removing the token from the DB.

This patch fixes this by simply removing a token from the totals if it
already exists there.

Fix #467