### PR TITLE
Add support for new assets and turn asset tests assertions into warnings

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -13,6 +13,9 @@ Changelog
 * :feature:`-` Added support for the following tokens
 
   - `Pixel <https://coinmarketcap.com/currencies/pixel/>`__
+  - `Bittrex Credit Tokens <https://bittrex.zendesk.com/hc/en-us/articles/360032214811/>`__
+  - `Cocos-BCX <https://coinmarketcap.com/currencies/cocos-bcx/>`__
+  - `Akropolis <https://coinmarketcap.com/currencies/akropolis/>`__
 
 * :release:`1.0.2 <2019-08-04>`
 * :feature:`-` Added support for the following tokens

--- a/rotkehlchen/assets/asset.py
+++ b/rotkehlchen/assets/asset.py
@@ -1,7 +1,6 @@
+from dataclasses import dataclass, field
 from functools import total_ordering
 from typing import Any, Optional
-
-from dataclasses import dataclass, field
 
 from rotkehlchen.assets.resolver import AssetResolver
 from rotkehlchen.constants.cryptocompare import WORLD_TO_CRYPTOCOMPARE
@@ -66,6 +65,8 @@ WORLD_TO_POLONIEX = {
 
 WORLD_TO_KRAKEN = {
     'ATOM': 'ATOM',
+    'BAT': 'BAT',
+    'BSV': 'BSV',
     'ETC': 'XETC',
     'ETH': 'XETH',
     'LTC': 'XLTC',
@@ -96,7 +97,7 @@ WORLD_TO_KRAKEN = {
     'VEN': 'XXVN',
     'DOGE': 'XXDG',
     'XTZ': 'XTZ',
-    'BSV': 'BSV',
+    'WAVES': 'WAVES',
 }
 
 WORLD_TO_BINANCE = {

--- a/rotkehlchen/assets/converters.py
+++ b/rotkehlchen/assets/converters.py
@@ -379,6 +379,9 @@ UNSUPPORTED_BITTREX_ASSETS = (
     # TUDA. As of 02/08/2019 no data found outside of Bittrex for this token
     # https://mobile.twitter.com/BittrexIntl/status/1156974900986490880
     'TUDA',
+    # TwelveShips. As of 23/08/2019 no data found outside of Bittrex for this token
+    # https://twitter.com/BittrexIntl/status/1164689364997353472
+    'TSHP',
 )
 
 

--- a/rotkehlchen/assets/converters.py
+++ b/rotkehlchen/assets/converters.py
@@ -4,6 +4,7 @@ from rotkehlchen.errors import DeserializationError, UnsupportedAsset
 
 KRAKEN_TO_WORLD = {
     'ATOM': 'ATOM',
+    'BAT': 'BAT',
     'XDAO': 'DAO',
     'XETC': 'ETC',
     'XETH': 'ETH',
@@ -43,6 +44,7 @@ KRAKEN_TO_WORLD = {
     'XXDG': 'DOGE',
     'XTZ': 'XTZ',
     'BSV': 'BSV',
+    'WAVES': 'WAVES',
 }
 
 

--- a/rotkehlchen/constants/cryptocompare.py
+++ b/rotkehlchen/constants/cryptocompare.py
@@ -263,6 +263,8 @@ WORLD_TO_CRYPTOCOMPARE = {
 KNOWN_TO_MISS_FROM_CRYPTOCOMPARE = (
     # This is just kraken's internal fee token
     'KFEE',
+    # This is just bittrex's internal credit token
+    'BTXCRD',
     # For us ACH is the Altcoin Herald token. For cryptocompare it's
     # Achievecoin
     # https://www.cryptocompare.com/coins/ach/overview

--- a/rotkehlchen/constants/cryptocompare.py
+++ b/rotkehlchen/constants/cryptocompare.py
@@ -394,6 +394,9 @@ KNOWN_TO_MISS_FROM_CRYPTOCOMPARE = (
     # Cloudbrid (https://www.cloudbric.io/)
     # is not in cryptocompare but is in paprika
     'CLB',
+    # COCOS-BCX (https://coinmarketcap.com/currencies/cocos-bcx/)
+    # is not in cryptocompare but is in paprika
+    'COCOS',
     # CruiseBit (https://coinmarketcap.com/currencies/cruisebit/)
     # is not in cryptocompare but is in paprika
     'CRBT',

--- a/rotkehlchen/constants/cryptocompare.py
+++ b/rotkehlchen/constants/cryptocompare.py
@@ -354,6 +354,9 @@ KNOWN_TO_MISS_FROM_CRYPTOCOMPARE = (
     # PolyAI (https://coinmarketcap.com/currencies/poly-ai/)
     # is not in cryptocompare but is in paprika
     'AI',
+    # Akropolis (https://coinmarketcap.com/currencies/akropolis/)
+    # is not in cryptocompare but is in paprika
+    'AKRO',
     # AiLink token (https://coinmarketcap.com/currencies/ailink-token/)
     # is not in cryptocompare but is in paprika
     'ALI',

--- a/rotkehlchen/data/all_assets.json
+++ b/rotkehlchen/data/all_assets.json
@@ -1442,6 +1442,11 @@
         "symbol": "BTU",
         "type": "ethereum token"
     },
+    "BTXCRD": {
+        "name": "Bittrex Credits",
+        "symbol": "BTXCRD",
+        "type": "exchange specific"
+    },
     "BURST": {
         "name": "Burst",
         "started": 1402531200,

--- a/rotkehlchen/data/all_assets.json
+++ b/rotkehlchen/data/all_assets.json
@@ -286,6 +286,14 @@
         "symbol": "AIX",
         "type": "ethereum token"
     },
+    "AKRO": {
+        "ethereum_address": "0x8Ab7404063Ec4DBcfd4598215992DC3F8EC853d7",
+        "ethereum_token_decimals": 18,
+        "name": "Akropolis",
+        "started": 1562371200,
+        "symbol": "AKRO",
+        "type": "ethereum token"
+    },
     "ALGO": {
         "name": "Algorand",
         "started": 1560902400,

--- a/rotkehlchen/data/all_assets.json
+++ b/rotkehlchen/data/all_assets.json
@@ -1926,6 +1926,14 @@
         "symbol": "COB",
         "type": "ethereum token"
     },
+    "COCOS": {
+        "ethereum_address": "0x0C6f5F7D555E7518f6841a79436BD2b1Eef03381",
+        "ethereum_token_decimals": 18,
+        "name": "Cocos-BCX",
+        "started": 1565777340,
+        "symbol": "COCOS",
+        "type": "ethereum token"
+    },
     "COFI": {
         "ethereum_address": "0x3136eF851592aCf49CA4C825131E364170FA32b3",
         "ethereum_token_decimals": 18,

--- a/rotkehlchen/exchanges/kraken.py
+++ b/rotkehlchen/exchanges/kraken.py
@@ -51,6 +51,7 @@ log = RotkehlchenLogsAdapter(logger)
 
 KRAKEN_ASSETS = (
     'ATOM',
+    'BAT',
     'XDAO',
     'XETC',
     'XETH',
@@ -82,6 +83,7 @@ KRAKEN_ASSETS = (
     'XXVN',
     'XXDG',
     'XTZ',
+    'WAVES',
 )
 
 KRAKEN_DELISTED = ('XDAO', 'XXVN', 'ZKRW', 'XNMC', 'BSV', 'XICN')

--- a/rotkehlchen/externalapis/coinmarketcap.py
+++ b/rotkehlchen/externalapis/coinmarketcap.py
@@ -24,6 +24,7 @@ KNOWN_TO_MISS_FROM_CMC = (
     '1CR',
     'DAO',
     'KFEE',
+    'BTXCRD',
     'AC',
     'ACH',
     'ADN',

--- a/rotkehlchen/externalapis/coinpaprika.py
+++ b/rotkehlchen/externalapis/coinpaprika.py
@@ -13,6 +13,7 @@ KNOWN_TO_MISS_FROM_PAPRIKA = (
     'ALGO',
     'DAO',
     'KFEE',
+    'BTXCRD'
     '1CR',
     'ACH',
     'AERO',

--- a/rotkehlchen/tests/test_binance.py
+++ b/rotkehlchen/tests/test_binance.py
@@ -1,3 +1,4 @@
+import warnings as test_warnings
 from unittest.mock import patch
 
 import pytest
@@ -12,7 +13,7 @@ from rotkehlchen.assets.converters import (
 from rotkehlchen.assets.resolver import AssetResolver
 from rotkehlchen.constants.assets import A_BTC, A_ETH
 from rotkehlchen.constants.misc import ZERO
-from rotkehlchen.errors import RemoteError, UnsupportedAsset
+from rotkehlchen.errors import RemoteError, UnknownAsset, UnsupportedAsset
 from rotkehlchen.exchanges.binance import Binance, trade_from_binance
 from rotkehlchen.exchanges.data_structures import Exchange, Trade, TradeType
 from rotkehlchen.fval import FVal
@@ -215,6 +216,10 @@ def test_binance_assets_are_known(
             _ = asset_from_binance(binance_asset)
         except UnsupportedAsset:
             assert binance_asset in UNSUPPORTED_BINANCE_ASSETS
+        except UnknownAsset as e:
+            test_warnings.warn(UserWarning(
+                f'Found unknown asset {e.asset_name} in Binance. Support for it has to be added'
+            ))
 
 
 def test_binance_query_balances_unknown_asset(function_scope_binance):

--- a/rotkehlchen/tests/test_binance.py
+++ b/rotkehlchen/tests/test_binance.py
@@ -218,7 +218,7 @@ def test_binance_assets_are_known(
             assert binance_asset in UNSUPPORTED_BINANCE_ASSETS
         except UnknownAsset as e:
             test_warnings.warn(UserWarning(
-                f'Found unknown asset {e.asset_name} in Binance. Support for it has to be added'
+                f'Found unknown asset {e.asset_name} in Binance. Support for it has to be added',
             ))
 
 

--- a/rotkehlchen/tests/test_bittrex.py
+++ b/rotkehlchen/tests/test_bittrex.py
@@ -52,7 +52,7 @@ def test_bittrex_assets_are_known(bittrex):
             assert symbol in UNSUPPORTED_BITTREX_ASSETS
         except UnknownAsset as e:
             test_warnings.warn(UserWarning(
-                f'Found unknown asset {e.asset_name} in Bittrex. Support for it has to be added'
+                f'Found unknown asset {e.asset_name} in Bittrex. Support for it has to be added',
             ))
 
 

--- a/rotkehlchen/tests/test_bittrex.py
+++ b/rotkehlchen/tests/test_bittrex.py
@@ -1,3 +1,4 @@
+import warnings as test_warnings
 from typing import Any, Dict, List
 from unittest.mock import patch
 
@@ -6,7 +7,7 @@ from rotkehlchen.assets.converters import UNSUPPORTED_BITTREX_ASSETS, asset_from
 from rotkehlchen.assets.resolver import AssetResolver
 from rotkehlchen.constants.assets import A_BTC, A_ETH
 from rotkehlchen.constants.misc import ZERO
-from rotkehlchen.errors import UnsupportedAsset
+from rotkehlchen.errors import UnknownAsset, UnsupportedAsset
 from rotkehlchen.exchanges.data_structures import Trade
 from rotkehlchen.fval import FVal
 from rotkehlchen.tests.utils.history import TEST_END_TS
@@ -49,6 +50,10 @@ def test_bittrex_assets_are_known(bittrex):
             _ = asset_from_bittrex(symbol)
         except UnsupportedAsset:
             assert symbol in UNSUPPORTED_BITTREX_ASSETS
+        except UnknownAsset as e:
+            test_warnings.warn(UserWarning(
+                f'Found unknown asset {e.asset_name} in Bittrex. Support for it has to be added'
+            ))
 
 
 def test_bittrex_query_balances_unknown_asset(bittrex):

--- a/rotkehlchen/tests/test_kraken.py
+++ b/rotkehlchen/tests/test_kraken.py
@@ -22,7 +22,7 @@ def test_coverage_of_kraken_balances(kraken):
     diff = expected_assets.symmetric_difference(got_assets)
     if len(diff) != 0:
         test_warnings.warn(UserWarning(
-            f"Our known assets don't match kraken's assets. Difference: {diff}"
+            f"Our known assets don't match kraken's assets. Difference: {diff}",
         ))
     else:
         # Make sure all assets are covered by our from and to functions

--- a/rotkehlchen/tests/test_kraken.py
+++ b/rotkehlchen/tests/test_kraken.py
@@ -1,3 +1,4 @@
+import warnings as test_warnings
 from unittest.mock import patch
 
 import pytest
@@ -19,13 +20,15 @@ def test_coverage_of_kraken_balances(kraken):
     got_assets = set(kraken.query_public('Assets').keys())
     expected_assets = (set(KRAKEN_ASSETS) - set(KRAKEN_DELISTED)).union(set(['BSV']))
     diff = expected_assets.symmetric_difference(got_assets)
-    assert len(diff) == 0, (
-        f"Our known assets don't match kraken's assets. Difference: {diff}"
-    )
-    # Make sure all assets are covered by our from and to functions
-    for kraken_asset in got_assets:
-        asset = asset_from_kraken(kraken_asset)
-        assert asset.to_kraken() == kraken_asset
+    if len(diff) != 0:
+        test_warnings.warn(UserWarning(
+            f"Our known assets don't match kraken's assets. Difference: {diff}"
+        ))
+    else:
+        # Make sure all assets are covered by our from and to functions
+        for kraken_asset in got_assets:
+            asset = asset_from_kraken(kraken_asset)
+            assert asset.to_kraken() == kraken_asset
 
 
 def test_querying_balances(kraken):

--- a/rotkehlchen/tests/test_poloniex.py
+++ b/rotkehlchen/tests/test_poloniex.py
@@ -1,4 +1,5 @@
 import os
+import warnings as test_warnings
 from unittest.mock import patch
 
 import pytest
@@ -6,7 +7,7 @@ import pytest
 from rotkehlchen.assets.asset import Asset
 from rotkehlchen.assets.converters import UNSUPPORTED_POLONIEX_ASSETS, asset_from_poloniex
 from rotkehlchen.constants.assets import A_BTC, A_ETH
-from rotkehlchen.errors import DeserializationError, UnsupportedAsset
+from rotkehlchen.errors import DeserializationError, UnknownAsset, UnsupportedAsset
 from rotkehlchen.exchanges.data_structures import Loan, Trade, TradeType
 from rotkehlchen.exchanges.poloniex import Poloniex, process_polo_loans, trade_from_poloniex
 from rotkehlchen.fval import FVal
@@ -404,6 +405,10 @@ def test_poloniex_assets_are_known(poloniex):
             _ = asset_from_poloniex(poloniex_asset)
         except UnsupportedAsset:
             assert poloniex_asset in UNSUPPORTED_POLONIEX_ASSETS
+        except UnknownAsset as e:
+            test_warnings.warn(UserWarning(
+                f'Found unknown asset {e.asset_name} in Poloniex. Support for it has to be added'
+            ))
 
 
 @pytest.mark.parametrize('use_clean_caching_directory', [True])

--- a/rotkehlchen/tests/test_poloniex.py
+++ b/rotkehlchen/tests/test_poloniex.py
@@ -407,7 +407,7 @@ def test_poloniex_assets_are_known(poloniex):
             assert poloniex_asset in UNSUPPORTED_POLONIEX_ASSETS
         except UnknownAsset as e:
             test_warnings.warn(UserWarning(
-                f'Found unknown asset {e.asset_name} in Poloniex. Support for it has to be added'
+                f'Found unknown asset {e.asset_name} in Poloniex. Support for it has to be added',
             ))
 
 


### PR DESCRIPTION
- From now on all tests that check that we support all assets listed on the supported exchanges will not fail if a new asset is added on the exchange side but instead issue a warning.

- Adding support for:
    - Cocos-BCX
    - Bittrex Credit Tokens
    - Akropolis

- Support WAVES and BAT in Kraken