### PR TITLE
Properly handle empty dict cryptocompare response

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,8 @@
 Changelog
 =========
 
+* :bug:`527` If cryptocompare query returns an empty object Rotki client no longer crashes.
+
 * :release:`1.0.4 <2019-10-04>`
 * :feature:`498` Users can now import data from Cointracking into Rotki. Create a CSV export from Cointracking and import it from the Import Data menu.
 * :bug:`500` Fix cryptocompare price queries for LBRY credits.

--- a/rotkehlchen/inquirer.py
+++ b/rotkehlchen/inquirer.py
@@ -46,8 +46,8 @@ def query_cryptocompare_for_fiat_price(asset: Asset) -> Price:
     # If there is an error in the response skip this token
     if 'USD' not in resp:
         error_message = ''
-        if resp['Response'] == 'Error':
-            error_message = resp['Message']
+        if resp.get('Response', None) == 'Error':
+            error_message = resp.get('Message', '')
 
         log.error(
             'Cryptocompare usd price query failed',


### PR DESCRIPTION
Fix #527 